### PR TITLE
adding BAL-A

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ COB Team Name or Author(s):
 - [ ] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
 - [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
 - [ ] Validate all addresses used are in Kovan changelog
-- [ ] Deploy spell to kovan `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 --network kovan build --extract && dapp create DssSpell --verify --network kovan --gas=XXX --gas-price="$(seth --to-wei YYY "gwei")"`
+- [ ] Deploy spell to kovan `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 build --extract && dapp create DssSpell --gas=5000000 --gas-price="$(seth --to-wei 3 "gwei")"`
 - [ ] Ensure contract is verified on `kovan` etherscan
 - [ ] Change test to use kovan spell address and deploy timestamp
 - [ ] Keep `Kovan-DssSpell.sol` and `Kovan-DssSpell.t.sol` the same, but make a copy in `archive`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+# Description
+
+Spell Description:
+
+COB Team Name or Author(s):
+
+# Contribution Checklist
+
+- [ ] First commit title starts with COB Team Name and Collateral type (e.g. `___-TOKEN-X`)
+- [ ] Code approved
+- [ ] Tests approved
+- [ ] CI Tests pass
+
+# Checklist
+
+- [ ] Every contract variable/method declared as public/external private/internal
+- [ ] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
+- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
+- [ ] Validate all addresses used are in Kovan changelog
+- [ ] Deploy spell to kovan `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 --network kovan build --extract && dapp create DssSpell --verify --network kovan --gas=XXX --gas-price="$(seth --to-wei YYY "gwei")"`
+- [ ] Ensure contract is verified on `kovan` etherscan
+- [ ] Change test to use kovan spell address and deploy timestamp
+- [ ] Keep `Kovan-DssSpell.sol` and `Kovan-DssSpell.t.sol` the same, but make a copy in `archive`
+- [ ] `squash and merge` this PR

--- a/archive/2020-10-21-AddBALA.sol
+++ b/archive/2020-10-21-AddBALA.sol
@@ -1,0 +1,187 @@
+// Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.5.12;
+
+import "lib/dss-interfaces/src/dapp/DSPauseAbstract.sol";
+import "lib/dss-interfaces/src/dss/CatAbstract.sol";
+import "lib/dss-interfaces/src/dss/FlipAbstract.sol";
+import "lib/dss-interfaces/src/dss/IlkRegistryAbstract.sol";
+import "lib/dss-interfaces/src/dss/GemJoinAbstract.sol";
+import "lib/dss-interfaces/src/dss/JugAbstract.sol";
+import "lib/dss-interfaces/src/dss/MedianAbstract.sol";
+import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
+import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
+import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
+import "lib/dss-interfaces/src/dss/VatAbstract.sol";
+import "lib/dss-interfaces/src/dss/FaucetAbstract.sol";
+
+contract SpellAction {
+    // KOVAN ADDRESSES
+    //
+    // The contracts in this list should correspond to MCD core contracts, verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/kovan/1.1.3/contracts.json
+
+    address constant MCD_VAT      = 0xbA987bDB501d131f766fEe8180Da5d81b34b69d9;
+    address constant MCD_CAT      = 0xdDb5F7A3A5558b9a6a1f3382BD75E2268d1c6958;
+    address constant MCD_JUG      = 0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD;
+    address constant MCD_SPOT     = 0x3a042de6413eDB15F2784f2f97cC68C7E9750b2D;
+    address constant MCD_POT      = 0xEA190DBDC7adF265260ec4dA6e9675Fd4f5A78bb;
+    address constant MCD_END      = 0x24728AcF2E2C403F5d2db4Df6834B8998e56aA5F;
+    address constant FLIPPER_MOM  = 0x50dC6120c67E456AdA2059cfADFF0601499cf681;
+    address constant OSM_MOM      = 0x5dA9D1C3d4f1197E5c52Ff963916Fe84D2F5d8f3;
+    address constant ILK_REGISTRY = 0xedE45A0522CA19e979e217064629778d6Cc2d9Ea;
+
+    address constant FAUCET       = 0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3;
+
+    address constant BAL            = 0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15;
+    address constant MCD_JOIN_BAL_A = 0x8De5EA9251E0576e3726c8766C56E27fAb2B6597;
+    address constant MCD_FLIP_BAL_A = 0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f;
+    address constant PIP_BAL        = 0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE;
+
+    uint256 constant THOUSAND = 10**3;
+    uint256 constant MILLION = 10**6;
+    uint256 constant WAD = 10**18;
+    uint256 constant RAY = 10**27;
+    uint256 constant RAD = 10**45;
+
+    // Many of the settings that change weekly rely on the rate accumulator
+    // described at https://docs.makerdao.com/smart-contract-modules/rates-module
+    // To check this yourself, use the following rate calculation (example 8%):
+    //
+    // $ bc -l <<< 'scale=27; e( l(1.08)/(60 * 60 * 24 * 365) )'
+    //
+    uint256 constant FIVE_PERCENT_RATE = 1000000001547125957863212448;
+
+    function execute() external {
+        bytes32 ilk = "BAL-A";
+
+        // Sanity checks
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).vat() == MCD_VAT, "join-vat-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).ilk() == ilk, "join-ilk-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).gem() == BAL, "join-gem-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).dec() == 18, "join-dec-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).vat() == MCD_VAT, "flip-vat-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).cat() == MCD_CAT, "flip-cat-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).ilk() == ilk, "flip-ilk-not-match");
+
+        // Set the BAL PIP in the Spotter
+        SpotAbstract(MCD_SPOT).file(ilk, "pip", PIP_BAL);
+
+        // Set the BAL-A Flipper in the Cat
+        CatAbstract(MCD_CAT).file(ilk, "flip", MCD_FLIP_BAL_A);
+
+        // Init BAL-A ilk in Vat & Jug
+        VatAbstract(MCD_VAT).init(ilk);
+        JugAbstract(MCD_JUG).init(ilk);
+
+        // Allow BAL-A Join to modify Vat registry
+        VatAbstract(MCD_VAT).rely(MCD_JOIN_BAL_A);
+        // Allow the BAL-A Flipper to reduce the Cat litterbox on deal()
+        CatAbstract(MCD_CAT).rely(MCD_FLIP_BAL_A);
+        // Allow Cat to kick auctions in BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(MCD_CAT);
+        // Allow End to yank auctions in BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(MCD_END);
+        // Allow FlipperMom to access to the BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(FLIPPER_MOM);
+        // Disallow Cat to kick auctions in BAL-A Flipper
+        // !!!!!!!! Only for certain collaterals that do not trigger liquidations like USDC-A)
+        // FlipperMomAbstract(FLIPPER_MOM).deny(MCD_FLIP_BAL_A);
+
+        // Allow OsmMom to access to the BAL Osm
+        // !!!!!!!! Only if PIP_BAL = Osm and hasn't been already relied due a previous deployed ilk
+        OsmAbstract(PIP_BAL).rely(OSM_MOM);
+        // Whitelist Osm to read the Median data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_BAL = Osm, its src is a Median and hasn't been already whitelisted due a previous deployed ilk
+        MedianAbstract(OsmAbstract(PIP_BAL).src()).kiss(PIP_BAL);
+        // Whitelist Spotter to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_BAL = Osm or PIP_BAL = Median and hasn't been already whitelisted due a previous deployed ilk
+        OsmAbstract(PIP_BAL).kiss(MCD_SPOT);
+        // Whitelist End to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
+        // !!!!!!!! Only if PIP_BAL = Osm or PIP_BAL = Median and hasn't been already whitelisted due a previous deployed ilk
+        OsmAbstract(PIP_BAL).kiss(MCD_END);
+        // Set BAL Osm in the OsmMom for new ilk
+        // !!!!!!!! Only if PIP_BAL = Osm
+        OsmMomAbstract(OSM_MOM).setOsm(ilk, PIP_BAL);
+
+        // Set the global debt ceiling
+        VatAbstract(MCD_VAT).file("Line", 1220 * MILLION * RAD);
+        // Set the BAL-A debt ceiling
+        VatAbstract(MCD_VAT).file(ilk, "line", 4 * MILLION * RAD);
+        // Set the BAL-A dust
+        VatAbstract(MCD_VAT).file(ilk, "dust", 100 * RAD);
+        // Set the Lot size
+        CatAbstract(MCD_CAT).file(ilk, "dunk", 500 * RAD);
+        // Set the BAL-A liquidation penalty (e.g. 13% => X = 113)
+        CatAbstract(MCD_CAT).file(ilk, "chop", 113 * WAD / 100);
+        // Set the BAL-A stability fee (e.g. 1% = 1000000000315522921573372069)
+        JugAbstract(MCD_JUG).file(ilk, "duty", FIVE_PERCENT_RATE);
+        // Set the BAL-A percentage between bids (e.g. 3% => X = 103)
+        FlipAbstract(MCD_FLIP_BAL_A).file("beg", 103 * WAD / 100);
+        // Set the BAL-A time max time between bids
+        FlipAbstract(MCD_FLIP_BAL_A).file("ttl", 1 hours);
+        // Set the BAL-A max auction duration to
+        FlipAbstract(MCD_FLIP_BAL_A).file("tau", 1 hours);
+        // Set the BAL-A min collateralization ratio (e.g. 150% => X = 150)
+        SpotAbstract(MCD_SPOT).file(ilk, "mat", 175 * RAY / 100);
+
+        // Update BAL-A spot value in Vat
+        SpotAbstract(MCD_SPOT).poke(ilk);
+
+        // Add new ilk to the IlkRegistry
+        IlkRegistryAbstract(ILK_REGISTRY).add(MCD_JOIN_BAL_A);
+
+        // Set gulp amount in faucet on kovan
+        FaucetAbstract(FAUCET).setAmt(BAL, 200 * WAD);
+    }
+}
+
+contract DssSpell {
+    DSPauseAbstract public pause =
+        DSPauseAbstract(0x8754E6ecb4fe68DaA5132c2886aB39297a5c7189);
+    address         public action;
+    bytes32         public tag;
+    uint256         public eta;
+    bytes           public sig;
+    uint256         public expiration;
+    bool            public done;
+
+    string constant public description = "Kovan Spell Deploy";
+
+    constructor() public {
+        sig = abi.encodeWithSignature("execute()");
+        action = address(new SpellAction());
+        bytes32 _tag;
+        address _action = action;
+        assembly { _tag := extcodehash(_action) }
+        tag = _tag;
+        expiration = now + 30 days;
+    }
+
+    function schedule() public {
+        require(now <= expiration, "This contract has expired");
+        require(eta == 0, "This spell has already been scheduled");
+        eta = now + DSPauseAbstract(pause).delay();
+        pause.plot(action, tag, sig, eta);
+    }
+
+    function cast() public {
+        require(!done, "spell-already-cast");
+        done = true;
+        pause.exec(action, tag, sig, eta);
+    }
+}

--- a/archive/2020-10-21-AddBALA.t.sol
+++ b/archive/2020-10-21-AddBALA.t.sol
@@ -1,0 +1,635 @@
+pragma solidity 0.5.12;
+
+import "ds-math/math.sol";
+import "ds-test/test.sol";
+import "lib/dss-interfaces/src/Interfaces.sol";
+import "./test/rates.sol";
+
+import {DssSpell, SpellAction} from "./Kovan-DssSpell.sol";
+
+interface Hevm {
+    function warp(uint) external;
+    function store(address,bytes32,bytes32) external;
+}
+
+contract DssSpellTest is DSTest, DSMath {
+    // populate with kovan spell if needed
+    address constant KOVAN_SPELL = address(
+      0x0DE068b775ED97f53981a733769146Aba3F4a1aC
+    );
+    // this needs to be updated
+    uint256 constant SPELL_CREATED = 1603315220;
+
+    struct CollateralValues {
+        uint256 line;
+        uint256 dust;
+        uint256 chop;
+        uint256 dunk;
+        uint256 pct;
+        uint256 mat;
+        uint256 beg;
+        uint48 ttl;
+        uint48 tau;
+        uint256 liquidations;
+    }
+
+    struct SystemValues {
+        uint256 dsr_rate;
+        uint256 vat_Line;
+        uint256 pause_delay;
+        uint256 vow_wait;
+        uint256 vow_dump;
+        uint256 vow_sump;
+        uint256 vow_bump;
+        uint256 vow_hump;
+        uint256 cat_box;
+        uint256 ilk_count;
+        mapping (bytes32 => CollateralValues) collaterals;
+    }
+
+    SystemValues afterSpell;
+
+    Hevm hevm;
+    Rates rates;
+
+    // KOVAN ADDRESSES
+    DSPauseAbstract      pause = DSPauseAbstract(    0x8754E6ecb4fe68DaA5132c2886aB39297a5c7189);
+    address         pauseProxy =                     0x0e4725db88Bb038bBa4C4723e91Ba183BE11eDf3;
+    DSChiefAbstract      chief = DSChiefAbstract(    0xbBFFC76e94B34F72D96D054b31f6424249c1337d);
+    VatAbstract            vat = VatAbstract(        0xbA987bDB501d131f766fEe8180Da5d81b34b69d9);
+    CatAbstract            cat = CatAbstract(        0xdDb5F7A3A5558b9a6a1f3382BD75E2268d1c6958);
+    VowAbstract            vow = VowAbstract(        0x0F4Cbe6CBA918b7488C26E29d9ECd7368F38EA3b);
+    PotAbstract            pot = PotAbstract(        0xEA190DBDC7adF265260ec4dA6e9675Fd4f5A78bb);
+    JugAbstract            jug = JugAbstract(        0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD);
+    SpotAbstract          spot = SpotAbstract(       0x3a042de6413eDB15F2784f2f97cC68C7E9750b2D);
+
+    DSTokenAbstract        gov = DSTokenAbstract(    0xAaF64BFCC32d0F15873a02163e7E500671a4ffcD);
+    EndAbstract            end = EndAbstract(        0x24728AcF2E2C403F5d2db4Df6834B8998e56aA5F);
+    IlkRegistryAbstract    reg = IlkRegistryAbstract(0xedE45A0522CA19e979e217064629778d6Cc2d9Ea);
+
+    OsmMomAbstract      osmMom = OsmMomAbstract(     0x5dA9D1C3d4f1197E5c52Ff963916Fe84D2F5d8f3);
+    FlipperMomAbstract flipMom = FlipperMomAbstract( 0x50dC6120c67E456AdA2059cfADFF0601499cf681);
+
+    // COMP-A specific
+    DSTokenAbstract       comp = DSTokenAbstract(    0x1dDe24ACE93F9F638Bfd6fCE1B38b842703Ea1Aa);
+    GemJoinAbstract  joinCOMPA = GemJoinAbstract(    0x16D567c1F6824ffFC460A11d48F61E010ae43766);
+    OsmAbstract        pipCOMP = OsmAbstract(        0xcc10b1C53f4BFFEE19d0Ad00C40D7E36a454D5c4);
+    FlipAbstract     flipCOMPA = FlipAbstract(       0x2917a962BC45ED48497de85821bddD065794DF6C);
+    MedianAbstract    medCOMPA = MedianAbstract(     0x18746A1CED49Ff06432400b8EdDcf77876EcA6f8);
+
+    // LRC-A specific
+    GemAbstract            lrc = GemAbstract(        0xF070662e48843934b5415f150a18C250d4D7B8aB);
+    GemJoinAbstract   joinLRCA = GemJoinAbstract(    0x436286788C5dB198d632F14A20890b0C4D236800);
+    OsmAbstract         pipLRC = OsmAbstract(        0xcEE47Bb8989f625b5005bC8b9f9A0B0892339721);
+    FlipAbstract      flipLRCA = FlipAbstract(       0xfC9496337538235669F4a19781234122c9455897);
+    MedianAbstract     medLRCA = MedianAbstract(     0x2aab6aDb9d202e411D2B29a6be1da80F648230f2);
+
+    // LINK-A specific
+    DSTokenAbstract       link = DSTokenAbstract(    0xa36085F69e2889c224210F603D836748e7dC0088);
+    GemJoinAbstract  joinLINKA = GemJoinAbstract(    0xF4Df626aE4fb446e2Dcce461338dEA54d2b9e09b);
+    OsmAbstract        pipLINK = OsmAbstract(        0x20D5A457e49D05fac9729983d9701E0C3079Efac);
+    FlipAbstract     flipLINKA = FlipAbstract(       0xfbDCDF5Bd98f68cEfc3f37829189b97B602eCFF2);
+    MedianAbstract    medLINKA = MedianAbstract(     0x7cb395DF9f1534cF528470e2F1AE2D1867d6253f);
+
+    // BAL-A specific
+    DSTokenAbstract       bal = DSTokenAbstract(     0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15);
+    GemJoinAbstract  joinBALA = GemJoinAbstract(     0x8De5EA9251E0576e3726c8766C56E27fAb2B6597);
+    OsmAbstract        pipBAL = OsmAbstract(         0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE);
+    FlipAbstract     flipBALA = FlipAbstract(        0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f);
+    MedianAbstract    medBALA = MedianAbstract(      0x0C472661dde5B08BEee6a7F8266720ea445830a3);
+
+    // Faucet
+    FaucetAbstract      faucet = FaucetAbstract(     0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3);
+
+    DssSpell spell;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    uint256 constant HUNDRED    = 10 ** 2;
+    uint256 constant THOUSAND   = 10 ** 3;
+    uint256 constant MILLION    = 10 ** 6;
+    uint256 constant BILLION    = 10 ** 9;
+    uint256 constant WAD        = 10 ** 18;
+    uint256 constant RAY        = 10 ** 27;
+    uint256 constant RAD        = 10 ** 45;
+
+    // Many of the settings that change weekly rely on the rate accumulator
+    // described at https://docs.makerdao.com/smart-contract-modules/rates-module
+    // To check this yourself, use the following rate calculation (example 8%):
+    //
+    // $ bc -l <<< 'scale=27; e( l(1.01)/(60 * 60 * 24 * 365) )'
+    //
+    // Rates table is in ./test/rates.sol
+
+    // not provided in DSMath
+    function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
+      assembly {
+        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
+        default {
+          switch mod(n, 2) case 0 { z := b } default { z := x }
+          let half := div(b, 2)  // for rounding.
+          for { n := div(n, 2) } n { n := div(n,2) } {
+            let xx := mul(x, x)
+            if iszero(eq(div(xx, x), x)) { revert(0,0) }
+            let xxRound := add(xx, half)
+            if lt(xxRound, xx) { revert(0,0) }
+            x := div(xxRound, b)
+            if mod(n,2) {
+              let zx := mul(z, x)
+              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+              let zxRound := add(zx, half)
+              if lt(zxRound, zx) { revert(0,0) }
+              z := div(zxRound, b)
+            }
+          }
+        }
+      }
+    }
+    // 10^-5 (tenth of a basis point) as a RAY
+    uint256 TOLERANCE = 10 ** 22;
+
+    function yearlyYield(uint256 duty) public pure returns (uint256) {
+        return rpow(duty, (365 * 24 * 60 *60), RAY);
+    }
+
+    function expectedRate(uint256 percentValue) public pure returns (uint256) {
+        return (10000 + percentValue) * (10 ** 23);
+    }
+
+    function diffCalc(uint256 expectedRate_, uint256 yearlyYield_) public pure returns (uint256) {
+        return (expectedRate_ > yearlyYield_) ? expectedRate_ - yearlyYield_ : yearlyYield_ - expectedRate_;
+    }
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+        rates = new Rates();
+
+        spell = KOVAN_SPELL != address(0) ? DssSpell(KOVAN_SPELL) : new DssSpell();
+
+        //
+        // Test for all system configuration changes
+        //
+        afterSpell = SystemValues({
+            dsr_rate:     0,               // In basis points
+            vat_Line:     1220 * MILLION,  // In whole Dai units
+            pause_delay:  60,              // In seconds
+            vow_wait:     3600,            // In seconds
+            vow_dump:     2,               // In whole Dai units
+            vow_sump:     50,              // In whole Dai units
+            vow_bump:     10,              // In whole Dai units
+            vow_hump:     500,             // In whole Dai units
+            cat_box:      10 * THOUSAND,   // In whole Dai units
+            ilk_count:    16               // Num expected in system
+        });
+
+        //
+        // Test for all collateral based changes here
+        //
+        afterSpell.collaterals["ETH-A"] = CollateralValues({
+            line:         540 * MILLION,   // In whole Dai units
+            dust:         100,             // In whole Dai units
+            pct:          0,               // In basis points
+            chop:         1300,            // In basis points
+            dunk:         500,             // In whole Dai units
+            mat:          15000,           // In basis points
+            beg:          300,             // In basis points
+            ttl:          1 hours,         // In seconds
+            tau:          1 hours,         // In seconds
+            liquidations: 1                // 1 if enabled
+        });
+        afterSpell.collaterals["ETH-B"] = CollateralValues({
+            line:         20 * MILLION,
+            dust:         100,
+            pct:          600,
+            chop:         1300,
+            dunk:         500,
+            mat:          13000,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["BAT-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDC-A"] = CollateralValues({
+            line:         400 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["USDC-B"] = CollateralValues({
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          5000,
+            chop:         1300,
+            dunk:         500,
+            mat:          12000,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["WBTC-A"] = CollateralValues({
+            line:         120 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["TUSD-A"] = CollateralValues({
+            line:         50 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["KNC-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["ZRX-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["MANA-A"] = CollateralValues({
+            line:         1 * MILLION,
+            dust:         100,
+            pct:          1200,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["USDT-A"] = CollateralValues({
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          800,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["PAXUSD-A"] = CollateralValues({
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 0
+        });
+        afterSpell.collaterals["COMP-A"] = CollateralValues({
+            line:         7 * MILLION,
+            dust:         100,
+            pct:          100,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LRC-A"] = CollateralValues({
+            line:         3 * MILLION,
+            dust:         100,
+            pct:          300,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["LINK-A"] = CollateralValues({
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          200,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+        afterSpell.collaterals["BAL-A"] = CollateralValues({
+            line:         4 * MILLION,
+            dust:         100,
+            pct:          500,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          300,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+    }
+
+    function vote() private {
+        if (chief.hat() != address(spell)) {
+            hevm.store(
+                address(gov),
+                keccak256(abi.encode(address(this), uint256(1))),
+                bytes32(uint256(999999999999 ether))
+            );
+            gov.approve(address(chief), uint256(-1));
+            chief.lock(sub(gov.balanceOf(address(this)), 1 ether));
+
+            assertTrue(!spell.done());
+
+            address[] memory yays = new address[](1);
+            yays[0] = address(spell);
+
+            chief.vote(yays);
+            chief.lift(address(spell));
+        }
+        assertEq(chief.hat(), address(spell));
+    }
+
+    function scheduleWaitAndCast() public {
+        spell.schedule();
+        hevm.warp(now + pause.delay());
+        spell.cast();
+    }
+
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    function checkSystemValues(SystemValues storage values) internal {
+        // dsr
+        uint expectedDSRRate = rates.rates(values.dsr_rate);
+        // make sure dsr is less than 100% APR
+        // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
+        // 1000000021979553151239153027
+        assertTrue(
+            pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027
+        );
+        assertTrue(diffCalc(expectedRate(values.dsr_rate), yearlyYield(expectedDSRRate)) <= TOLERANCE);
+
+        {
+        // Line values in RAD
+        uint normalizedLine = values.vat_Line * RAD;
+        assertEq(vat.Line(), normalizedLine);
+        assertTrue(
+            (vat.Line() >= RAD && vat.Line() < 100 * BILLION * RAD) ||
+            vat.Line() == 0
+        );
+        }
+
+        // Pause delay
+        assertEq(pause.delay(), values.pause_delay);
+
+        // wait
+        assertEq(vow.wait(), values.vow_wait);
+        {
+        // dump values in WAD
+        uint normalizedDump = values.vow_dump * WAD;
+        assertEq(vow.dump(), normalizedDump);
+        assertTrue(
+            (vow.dump() >= WAD && vow.dump() < 2 * THOUSAND * WAD) ||
+            vow.dump() == 0
+        );
+        }
+        {
+        // sump values in RAD
+        uint normalizedSump = values.vow_sump * RAD;
+        assertEq(vow.sump(), normalizedSump);
+        assertTrue(
+            (vow.sump() >= RAD && vow.sump() < 500 * THOUSAND * RAD) ||
+            vow.sump() == 0
+        );
+        }
+        {
+        // bump values in RAD
+        uint normalizedBump = values.vow_bump * RAD;
+        assertEq(vow.bump(), normalizedBump);
+        assertTrue(
+            (vow.bump() >= RAD && vow.bump() < HUNDRED * THOUSAND * RAD) ||
+            vow.bump() == 0
+        );
+        }
+        {
+        // hump values in RAD
+        uint normalizedHump = values.vow_hump * RAD;
+        assertEq(vow.hump(), normalizedHump);
+        assertTrue(
+            (vow.hump() >= RAD && vow.hump() < HUNDRED * MILLION * RAD) ||
+            vow.hump() == 0
+        );
+        }
+
+        // box values in RAD
+        {
+            uint normalizedBox = values.cat_box * RAD;
+            assertEq(cat.box(), normalizedBox);
+        }
+
+        // check number of ilks
+        assertEq(reg.count(), values.ilk_count);
+
+    }
+
+    function checkCollateralValues(bytes32 ilk, SystemValues storage values) internal {
+        (uint duty,)  = jug.ilks(ilk);
+        assertEq(duty, rates.rates(values.collaterals[ilk].pct));
+        // make sure duty is less than 1000% APR
+        // bc -l <<< 'scale=27; e( l(10.00)/(60 * 60 * 24 * 365) )'
+        // 1000000073014496989316680335
+        assertTrue(duty >= RAY && duty < 1000000073014496989316680335);  // gt 0 and lt 1000%
+        assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct))) <= TOLERANCE);
+        assertTrue(values.collaterals[ilk].pct < THOUSAND * THOUSAND);   // check value lt 1000%
+        {
+        (,,, uint line, uint dust) = vat.ilks(ilk);
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestLine = values.collaterals[ilk].line * RAD;
+        assertEq(line, normalizedTestLine);
+        assertTrue((line >= RAD && line < BILLION * RAD) || line == 0);  // eq 0 or gt eq 1 RAD and lt 1B
+        uint normalizedTestDust = values.collaterals[ilk].dust * RAD;
+        assertEq(dust, normalizedTestDust);
+        assertTrue((dust >= RAD && dust < 10 * THOUSAND * RAD) || dust == 0); // eq 0 or gt eq 1 and lt 10k
+        }
+        {
+        (, uint chop, uint dunk) = cat.ilks(ilk);
+        uint normalizedTestChop = (values.collaterals[ilk].chop * 10**14) + WAD;
+        assertEq(chop, normalizedTestChop);
+        // make sure chop is less than 100%
+        assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestDunk = values.collaterals[ilk].dunk * RAD;
+        assertEq(dunk, normalizedTestDunk);
+        // put back in after LIQ-1.2
+        assertTrue(dunk >= RAD && dunk < MILLION * RAD);
+        }
+        {
+        (,uint mat) = spot.ilks(ilk);
+        // Convert BP to system expected value
+        uint normalizedTestMat = (values.collaterals[ilk].mat * 10**23);
+        assertEq(mat, normalizedTestMat);
+        assertTrue(mat >= RAY && mat < 10 * RAY);    // cr eq 100% and lt 1000%
+        }
+        {
+        (address flipper,,) = cat.ilks(ilk);
+        FlipAbstract flip = FlipAbstract(flipper);
+        // Convert BP to system expected value
+        uint normalizedTestBeg = (values.collaterals[ilk].beg + 10000)  * 10**14;
+        assertEq(uint(flip.beg()), normalizedTestBeg);
+        assertTrue(flip.beg() >= WAD && flip.beg() < 105 * WAD / 100);  // gt eq 0% and lt 5%
+        assertEq(uint(flip.ttl()), values.collaterals[ilk].ttl);
+        assertTrue(flip.ttl() >= 600 && flip.ttl() < 10 hours);         // gt eq 10 minutes and lt 10 hours
+        assertEq(uint(flip.tau()), values.collaterals[ilk].tau);
+        assertTrue(flip.tau() >= 600 && flip.tau() <= 1 hours);          // gt eq 10 minutes and lt eq 1 hours
+
+        assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);  // liquidations == 1 => on
+        }
+    }
+
+    function testSpellIsCast() public {
+        string memory description = new DssSpell().description();
+        assertTrue(bytes(description).length > 0);
+        // DS-Test can't handle strings directly, so cast to a bytes32.
+        assertEq(stringToBytes32(spell.description()),
+                stringToBytes32(description));
+
+        if(address(spell) != address(KOVAN_SPELL)) {
+            assertEq(spell.expiration(), (now + 30 days));
+        } else {
+            assertEq(spell.expiration(), (SPELL_CREATED + 30 days));
+        }
+
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        checkSystemValues(afterSpell);
+
+        bytes32[] memory ilks = reg.list();
+        for(uint i = 0; i < ilks.length; i++) {
+            checkCollateralValues(ilks[i],  afterSpell);
+        }
+    }
+
+    function testSpellIsCast_BAL_INTEGRATION() public {
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        pipBAL.poke();
+        hevm.warp(now + 3601);
+        pipBAL.poke();
+        spot.poke("BAL-A");
+
+        // Check faucet amount
+        uint256 faucetAmount = faucet.amt(address(bal));
+        assertTrue(faucetAmount > 0);
+        faucet.gulp(address(bal));
+        assertEq(bal.balanceOf(address(this)), faucetAmount);
+
+        // Check median matches pip.src()
+        assertEq(pipBAL.src(), address(medBALA));
+
+        // Authorization
+        assertEq(joinBALA.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(joinBALA)), 1);
+        assertEq(flipBALA.wards(address(end)), 1);
+        assertEq(flipBALA.wards(address(flipMom)), 1);
+        assertEq(pipBAL.wards(address(osmMom)), 1);
+        assertEq(pipBAL.bud(address(spot)), 1);
+        assertEq(pipBAL.bud(address(end)), 1);
+        assertEq(MedianAbstract(pipBAL.src()).bud(address(pipBAL)), 1);
+
+        // Join to adapter
+        assertEq(vat.gem("BAL-A", address(this)), 0);
+        bal.approve(address(joinBALA), faucetAmount);
+        joinBALA.join(address(this), faucetAmount);
+        assertEq(bal.balanceOf(address(this)), 0);
+        assertEq(vat.gem("BAL-A", address(this)), faucetAmount);
+
+        // Deposit collateral, generate DAI
+        assertEq(vat.dai(address(this)), 0);
+        vat.frob("BAL-A", address(this), address(this), address(this), int(faucetAmount), int(100 * WAD));
+        assertEq(vat.gem("BAL-A", address(this)), 0);
+        assertEq(vat.dai(address(this)), 100 * RAD);
+
+        // Payback DAI, withdraw collateral
+        vat.frob("BAL-A", address(this), address(this), address(this), -int(faucetAmount), -int(100 * WAD));
+        assertEq(vat.gem("BAL-A", address(this)), faucetAmount);
+        assertEq(vat.dai(address(this)), 0);
+
+        // Withdraw from adapter
+        joinBALA.exit(address(this), faucetAmount);
+        assertEq(bal.balanceOf(address(this)), faucetAmount);
+        assertEq(vat.gem("BAL-A", address(this)), 0);
+
+        // Generate new DAI to force a liquidation
+        bal.approve(address(joinBALA), faucetAmount);
+        joinBALA.join(address(this), faucetAmount);
+        (,,uint256 spotV,,) = vat.ilks("BAL-A");
+        // dart max amount of DAI
+        vat.frob("BAL-A", address(this), address(this), address(this), int(faucetAmount), int(mul(faucetAmount, spotV) / RAY));
+        hevm.warp(now + 1);
+        jug.drip("BAL-A");
+        assertEq(flipBALA.kicks(), 0);
+        cat.bite("BAL-A", address(this));
+        assertEq(flipBALA.kicks(), 1);
+    }
+
+}

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -26,11 +26,7 @@ import "lib/dss-interfaces/src/dss/OsmAbstract.sol";
 import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
 import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
 import "lib/dss-interfaces/src/dss/VatAbstract.sol";
-
-// DO NOT REMOVE THIS ABSTRACT
-interface FaucetAbstract {
-    function setAmt(address, uint256) external;
-}
+import "lib/dss-interfaces/src/dss/FaucetAbstract.sol";
 
 contract SpellAction {
     address constant MCD_VAT      = 0xbA987bDB501d131f766fEe8180Da5d81b34b69d9;
@@ -46,7 +42,7 @@ contract SpellAction {
     address constant FAUCET       = 0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3;
 
     address constant BAL            = 0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15;
-    address constant MCD_JOIN_BAL_A = 0x17D3fd747FCc1BA15DC07f077ccd5Fc1902e0F08;
+    address constant MCD_JOIN_BAL_A = 0x8De5EA9251E0576e3726c8766C56E27fAb2B6597;
     address constant MCD_FLIP_BAL_A = 0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f;
     address constant PIP_BAL        = 0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE;
 
@@ -62,7 +58,7 @@ contract SpellAction {
     //
     // $ bc -l <<< 'scale=27; e( l(1.08)/(60 * 60 * 24 * 365) )'
     //
-    uint256 constant public X_PERCENT_RATE = ;
+    uint256 constant FIVE_PERCENT_RATE = 1000000001547125957863212448;
 
     function execute() external {
         bytes32 ilk = "BAL-A";
@@ -127,7 +123,7 @@ contract SpellAction {
         // Set the BAL-A liquidation penalty (e.g. 13% => X = 113)
         CatAbstract(MCD_CAT).file(ilk, "chop", 113 * WAD / 100);
         // Set the BAL-A stability fee (e.g. 1% = 1000000000315522921573372069)
-        JugAbstract(MCD_JUG).file(ilk, "duty", 1000000001547125957863212448);
+        JugAbstract(MCD_JUG).file(ilk, "duty", FIVE_PERCENT_RATE);
         // Set the BAL-A percentage between bids (e.g. 3% => X = 103)
         FlipAbstract(MCD_FLIP_BAL_A).file("beg", 103 * WAD / 100);
         // Set the BAL-A time max time between bids

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -27,132 +27,124 @@ import "lib/dss-interfaces/src/dss/OsmMomAbstract.sol";
 import "lib/dss-interfaces/src/dss/SpotAbstract.sol";
 import "lib/dss-interfaces/src/dss/VatAbstract.sol";
 
+// DO NOT REMOVE THIS ABSTRACT
 interface FaucetAbstract {
     function setAmt(address, uint256) external;
 }
 
 contract SpellAction {
-    // KOVAN ADDRESSES
-    //
-    // The contracts in this list should correspond to MCD core contracts, verify
-    //  against the current release list at:
-    //     https://changelog.makerdao.com/releases/kovan/1.1.2/contracts.json
+    address constant MCD_VAT      = 0xbA987bDB501d131f766fEe8180Da5d81b34b69d9;
+    address constant MCD_CAT      = 0xdDb5F7A3A5558b9a6a1f3382BD75E2268d1c6958;
+    address constant MCD_JUG      = 0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD;
+    address constant MCD_SPOT     = 0x3a042de6413eDB15F2784f2f97cC68C7E9750b2D;
+    address constant MCD_POT      = 0xEA190DBDC7adF265260ec4dA6e9675Fd4f5A78bb;
+    address constant MCD_END      = 0x24728AcF2E2C403F5d2db4Df6834B8998e56aA5F;
+    address constant FLIPPER_MOM  = 0x50dC6120c67E456AdA2059cfADFF0601499cf681;
+    address constant OSM_MOM      = 0x5dA9D1C3d4f1197E5c52Ff963916Fe84D2F5d8f3;
+    address constant ILK_REGISTRY = 0xedE45A0522CA19e979e217064629778d6Cc2d9Ea;
 
-    address constant MCD_VAT         = 0xbA987bDB501d131f766fEe8180Da5d81b34b69d9;
-    address constant MCD_CAT         = 0xdDb5F7A3A5558b9a6a1f3382BD75E2268d1c6958;
-    address constant MCD_JUG         = 0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD;
-    address constant MCD_SPOT        = 0x3a042de6413eDB15F2784f2f97cC68C7E9750b2D;
-    address constant MCD_POT         = 0xEA190DBDC7adF265260ec4dA6e9675Fd4f5A78bb;
-    address constant MCD_END         = 0x24728AcF2E2C403F5d2db4Df6834B8998e56aA5F;
-    address constant FLIPPER_MOM     = 0x50dC6120c67E456AdA2059cfADFF0601499cf681;
-    address constant OSM_MOM         = 0x5dA9D1C3d4f1197E5c52Ff963916Fe84D2F5d8f3;
-    address constant ILK_REGISTRY    = 0xedE45A0522CA19e979e217064629778d6Cc2d9Ea;
-    address constant FAUCET          = 0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3;
+    address constant FAUCET       = 0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3;
 
-    // ETH-B specific addresses
-    //   > seth --to-bytes32 $(seth --from-ascii "ETH-B")
-    //   0x4554482d42000000000000000000000000000000000000000000000000000000
-    address constant ETH            = 0xd0A1E359811322d97991E03f863a0C30C2cF029C;
-    address constant MCD_JOIN_ETH_B = 0xd19A770F00F89e6Dd1F12E6D6E6839b95C084D85;
-    address constant MCD_FLIP_ETH_B = 0x360e15d419c14f6060c88Ac0741323C37fBfDa2D;
-    address constant PIP_ETH        = 0x75dD74e8afE8110C8320eD397CcCff3B8134d981; // OSM
+    address constant BAL            = 0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15;
+    address constant MCD_JOIN_BAL_A = 0x17D3fd747FCc1BA15DC07f077ccd5Fc1902e0F08;
+    address constant MCD_FLIP_BAL_A = 0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f;
+    address constant PIP_BAL        = 0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE;
 
-
-
-    // Decimals & precision
-    uint256 constant THOUSAND = 10 ** 3;
-    uint256 constant MILLION  = 10 ** 6;
-    uint256 constant WAD      = 10 ** 18;
-    uint256 constant RAY      = 10 ** 27;
-    uint256 constant RAD      = 10 ** 45;
+    uint256 constant THOUSAND = 10**3;
+    uint256 constant MILLION = 10**6;
+    uint256 constant WAD = 10**18;
+    uint256 constant RAY = 10**27;
+    uint256 constant RAD = 10**45;
 
     // Many of the settings that change weekly rely on the rate accumulator
     // described at https://docs.makerdao.com/smart-contract-modules/rates-module
     // To check this yourself, use the following rate calculation (example 8%):
     //
-    // $ bc -l <<< 'scale=27; e( l(1.01)/(60 * 60 * 24 * 365) )'
+    // $ bc -l <<< 'scale=27; e( l(1.08)/(60 * 60 * 24 * 365) )'
     //
-    uint256 constant    SIX_PERCENT_RATE = 1000000001847694957439350562;
+    uint256 constant public X_PERCENT_RATE = ;
 
     function execute() external {
-        /*** ETH-B Collateral Onboarding ***/
-        bytes32 ilk = "ETH-B";
+        bytes32 ilk = "BAL-A";
 
         // Sanity checks
-        require(GemJoinAbstract(MCD_JOIN_ETH_B).vat() == MCD_VAT, "join-vat-not-match");
-        require(GemJoinAbstract(MCD_JOIN_ETH_B).ilk() == ilk, "join-ilk-not-match");
-        require(GemJoinAbstract(MCD_JOIN_ETH_B).gem() == ETH, "join-gem-not-match");
-        require(GemJoinAbstract(MCD_JOIN_ETH_B).dec() == 18, "join-dec-not-match");
-        require(FlipAbstract(MCD_FLIP_ETH_B).vat() == MCD_VAT, "flip-vat-not-match");
-        require(FlipAbstract(MCD_FLIP_ETH_B).cat() == MCD_CAT, "flip-cat-not-match");
-        require(FlipAbstract(MCD_FLIP_ETH_B).ilk() == ilk, "flip-ilk-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).vat() == MCD_VAT, "join-vat-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).ilk() == ilk, "join-ilk-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).gem() == BAL, "join-gem-not-match");
+        require(GemJoinAbstract(MCD_JOIN_BAL_A).dec() == 18, "join-dec-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).vat() == MCD_VAT, "flip-vat-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).cat() == MCD_CAT, "flip-cat-not-match");
+        require(FlipAbstract(MCD_FLIP_BAL_A).ilk() == ilk, "flip-ilk-not-match");
 
-        // Set the TOKEN PIP in the Spotter
-        SpotAbstract(MCD_SPOT).file(ilk, "pip", PIP_ETH);
+        // Set the BAL PIP in the Spotter
+        SpotAbstract(MCD_SPOT).file(ilk, "pip", PIP_BAL);
 
-        // Set the TOKEN-LETTER Flipper in the Cat
-        CatAbstract(MCD_CAT).file(ilk, "flip", MCD_FLIP_ETH_B);
+        // Set the BAL-A Flipper in the Cat
+        CatAbstract(MCD_CAT).file(ilk, "flip", MCD_FLIP_BAL_A);
 
-        // Init TOKEN-LETTER ilk in Vat & Jug
+        // Init BAL-A ilk in Vat & Jug
         VatAbstract(MCD_VAT).init(ilk);
         JugAbstract(MCD_JUG).init(ilk);
 
-        // Allow TOKEN-LETTER Join to modify Vat registry
-        VatAbstract(MCD_VAT).rely(MCD_JOIN_ETH_B);
-        // Allow the TOKEN-LETTER Flipper to reduce the Cat litterbox on deal()
-        CatAbstract(MCD_CAT).rely(MCD_FLIP_ETH_B);
-        // Allow Cat to kick auctions in TOKEN-LETTER Flipper
-        FlipAbstract(MCD_FLIP_ETH_B).rely(MCD_CAT);
-        // Allow End to yank auctions in TOKEN-LETTER Flipper
-        FlipAbstract(MCD_FLIP_ETH_B).rely(MCD_END);
-        // Allow FlipperMom to access to the TOKEN-LETTER Flipper
-        FlipAbstract(MCD_FLIP_ETH_B).rely(FLIPPER_MOM);
-        // Disallow Cat to kick auctions in TOKEN-LETTER Flipper
+        // Allow BAL-A Join to modify Vat registry
+        VatAbstract(MCD_VAT).rely(MCD_JOIN_BAL_A);
+        // Allow the BAL-A Flipper to reduce the Cat litterbox on deal()
+        CatAbstract(MCD_CAT).rely(MCD_FLIP_BAL_A);
+        // Allow Cat to kick auctions in BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(MCD_CAT);
+        // Allow End to yank auctions in BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(MCD_END);
+        // Allow FlipperMom to access to the BAL-A Flipper
+        FlipAbstract(MCD_FLIP_BAL_A).rely(FLIPPER_MOM);
+        // Disallow Cat to kick auctions in BAL-A Flipper
         // !!!!!!!! Only for certain collaterals that do not trigger liquidations like USDC-A)
-        //FlipperMomAbstract(FLIPPER_MOM).deny(MCD_FLIP_ETH_B);
+        // FlipperMomAbstract(FLIPPER_MOM).deny(MCD_FLIP_BAL_A);
 
-        // Allow OsmMom to access to the TOKEN Osm
-        // !!!!!!!! Only if PIP_TOKEN = Osm and hasn't been already relied due a previous deployed ilk
-        //OsmAbstract(PIP_TOKEN).rely(OSM_MOM);
+        // Allow OsmMom to access to the BAL Osm
+        // !!!!!!!! Only if PIP_BAL = Osm and hasn't been already relied due a previous deployed ilk
+        OsmAbstract(PIP_BAL).rely(OSM_MOM);
         // Whitelist Osm to read the Median data (only necessary if it is the first time the token is being added to an ilk)
-        // !!!!!!!! Only if PIP_TOKEN = Osm, its src is a Median and hasn't been already whitelisted due a previous deployed ilk
-        //MedianAbstract(OsmAbstract(PIP_TOKEN).src()).kiss(PIP_TOKEN);
+        // !!!!!!!! Only if PIP_BAL = Osm, its src is a Median and hasn't been already whitelisted due a previous deployed ilk
+        MedianAbstract(OsmAbstract(PIP_BAL).src()).kiss(PIP_BAL);
         // Whitelist Spotter to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
-        // !!!!!!!! Only if PIP_TOKEN = Osm or PIP_TOKEN = Median and hasn't been already whitelisted due a previous deployed ilk
-        //OsmAbstract(PIP_TOKEN).kiss(MCD_SPOT);
+        // !!!!!!!! Only if PIP_BAL = Osm or PIP_BAL = Median and hasn't been already whitelisted due a previous deployed ilk
+        OsmAbstract(PIP_BAL).kiss(MCD_SPOT);
         // Whitelist End to read the Osm data (only necessary if it is the first time the token is being added to an ilk)
-        // !!!!!!!! Only if PIP_TOKEN = Osm or PIP_TOKEN = Median and hasn't been already whitelisted due a previous deployed ilk
-        //OsmAbstract(PIP_TOKEN).kiss(MCD_END);
-        // Set TOKEN Osm in the OsmMom for new ilk
-        // !!!!!!!! Only if PIP_TOKEN = Osm
-        OsmMomAbstract(OSM_MOM).setOsm(ilk, PIP_ETH);
+        // !!!!!!!! Only if PIP_BAL = Osm or PIP_BAL = Median and hasn't been already whitelisted due a previous deployed ilk
+        OsmAbstract(PIP_BAL).kiss(MCD_END);
+        // Set BAL Osm in the OsmMom for new ilk
+        // !!!!!!!! Only if PIP_BAL = Osm
+        OsmMomAbstract(OSM_MOM).setOsm(ilk, PIP_BAL);
 
         // Set the global debt ceiling
-        VatAbstract(MCD_VAT).file("Line", 1216 * MILLION * RAD);
-        // Set the TOKEN-LETTER debt ceiling
-        VatAbstract(MCD_VAT).file(ilk, "line", 20 * MILLION * RAD);
-        // Set the TOKEN-LETTER dust
+        VatAbstract(MCD_VAT).file("Line", 1220 * MILLION * RAD);
+        // Set the BAL-A debt ceiling
+        VatAbstract(MCD_VAT).file(ilk, "line", 4 * MILLION * RAD);
+        // Set the BAL-A dust
         VatAbstract(MCD_VAT).file(ilk, "dust", 100 * RAD);
         // Set the Lot size
-        CatAbstract(MCD_CAT).file(ilk, "dunk", 500 * RAD); // Should be 50000 on mainnet
-        // Set the TOKEN-LETTER liquidation penalty (e.g. 13% => X = 113)
+        CatAbstract(MCD_CAT).file(ilk, "dunk", 500 * RAD);
+        // Set the BAL-A liquidation penalty (e.g. 13% => X = 113)
         CatAbstract(MCD_CAT).file(ilk, "chop", 113 * WAD / 100);
-        // Set the TOKEN-LETTER stability fee (e.g. 1% = 1000000000315522921573372069)
-        JugAbstract(MCD_JUG).file(ilk, "duty", SIX_PERCENT_RATE);
-        // Set the TOKEN-LETTER percentage between bids (e.g. 3% => X = 103)
-        FlipAbstract(MCD_FLIP_ETH_B).file("beg", 103 * WAD / 100);
-        // Set the TOKEN-LETTER time max time between bids
-        FlipAbstract(MCD_FLIP_ETH_B).file("ttl", 1 hours); // 6 hours mainnet
-        // Set the TOKEN-LETTER max auction duration to
-        FlipAbstract(MCD_FLIP_ETH_B).file("tau", 1 hours); // 6 hours mainnet
-        // Set the TOKEN-LETTER min collateralization ratio (e.g. 150% => X = 150)
-        SpotAbstract(MCD_SPOT).file(ilk, "mat", 130 * RAY / 100);
+        // Set the BAL-A stability fee (e.g. 1% = 1000000000315522921573372069)
+        JugAbstract(MCD_JUG).file(ilk, "duty", 1000000001547125957863212448);
+        // Set the BAL-A percentage between bids (e.g. 3% => X = 103)
+        FlipAbstract(MCD_FLIP_BAL_A).file("beg", 103 * WAD / 100);
+        // Set the BAL-A time max time between bids
+        FlipAbstract(MCD_FLIP_BAL_A).file("ttl", 1 hours);
+        // Set the BAL-A max auction duration to
+        FlipAbstract(MCD_FLIP_BAL_A).file("tau", 1 hours);
+        // Set the BAL-A min collateralization ratio (e.g. 150% => X = 150)
+        SpotAbstract(MCD_SPOT).file(ilk, "mat", 175 * RAY / 100);
 
-        // Update TOKEN-LETTER spot value in Vat
+        // Update BAL-A spot value in Vat
         SpotAbstract(MCD_SPOT).poke(ilk);
 
         // Add new ilk to the IlkRegistry
-        IlkRegistryAbstract(ILK_REGISTRY).add(MCD_JOIN_ETH_B);
+        IlkRegistryAbstract(ILK_REGISTRY).add(MCD_JOIN_BAL_A);
+
+        // Set gulp amount in faucet on kovan
+        FaucetAbstract(FAUCET).setAmt(BAL, 200 * WAD);
     }
 }
 

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -29,6 +29,12 @@ import "lib/dss-interfaces/src/dss/VatAbstract.sol";
 import "lib/dss-interfaces/src/dss/FaucetAbstract.sol";
 
 contract SpellAction {
+    // KOVAN ADDRESSES
+    //
+    // The contracts in this list should correspond to MCD core contracts, verify
+    //  against the current release list at:
+    //     https://changelog.makerdao.com/releases/kovan/1.1.3/contracts.json
+
     address constant MCD_VAT      = 0xbA987bDB501d131f766fEe8180Da5d81b34b69d9;
     address constant MCD_CAT      = 0xdDb5F7A3A5558b9a6a1f3382BD75E2268d1c6958;
     address constant MCD_JUG      = 0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD;

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -12,15 +12,9 @@ interface Hevm {
     function store(address,bytes32,bytes32) external;
 }
 
-interface FaucetAbstract {
-    function amt(address) external view returns (uint256);
-}
-
 contract DssSpellTest is DSTest, DSMath {
     // populate with kovan spell if needed
-    address constant KOVAN_SPELL = address(
-        0x79e92D6e1f041A98df60D7D5540D1A1697021398
-    );
+    address constant KOVAN_SPELL = address(0);
     // this needs to be updated
     uint256 constant SPELL_CREATED = 1602770824;
 
@@ -38,8 +32,7 @@ contract DssSpellTest is DSTest, DSMath {
     }
 
     struct SystemValues {
-        uint256 pot_dsr;
-        uint256 pot_dsrPct;
+        uint256 dsr_rate;
         uint256 vat_Line;
         uint256 pause_delay;
         uint256 vow_wait;
@@ -48,6 +41,7 @@ contract DssSpellTest is DSTest, DSMath {
         uint256 vow_bump;
         uint256 vow_hump;
         uint256 cat_box;
+        uint256 ilk_count;
         mapping (bytes32 => CollateralValues) collaterals;
     }
 
@@ -97,7 +91,7 @@ contract DssSpellTest is DSTest, DSMath {
 
     // BAL-A specific
     DSTokenAbstract       bal = DSTokenAbstract(     0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15);
-    GemJoinAbstract  joinBALA = GemJoinAbstract(     0x17D3fd747FCc1BA15DC07f077ccd5Fc1902e0F08);
+    GemJoinAbstract  joinBALA = GemJoinAbstract(     0x8De5EA9251E0576e3726c8766C56E27fAb2B6597);
     OsmAbstract        pipBAL = OsmAbstract(         0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE);
     FlipAbstract     flipBALA = FlipAbstract(        0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f);
     MedianAbstract    medBALA = MedianAbstract(      0x0C472661dde5B08BEee6a7F8266720ea445830a3);
@@ -159,7 +153,7 @@ contract DssSpellTest is DSTest, DSMath {
     }
 
     function expectedRate(uint256 percentValue) public pure returns (uint256) {
-        return (100000 + percentValue) * (10 ** 22);
+        return (10000 + percentValue) * (10 ** 23);
     }
 
     function diffCalc(uint256 expectedRate_, uint256 yearlyYield_) public pure returns (uint256) {
@@ -176,209 +170,209 @@ contract DssSpellTest is DSTest, DSMath {
         // Test for all system configuration changes
         //
         afterSpell = SystemValues({
-            pot_dsr: 1000000000000000000000000000,
-            pot_dsrPct: 0 * 1000,
-            vat_Line: 1216 * MILLION * RAD,
-            pause_delay: 60,
-            vow_wait: 3600,
-            vow_dump: 2 * WAD,
-            vow_sump: 50 * RAD,
-            vow_bump: 10 * RAD,
-            vow_hump: 500 * RAD,
-            cat_box: 10 * THOUSAND * RAD
+            dsr_rate:     0,               // In basis points
+            vat_Line:     1220 * MILLION,  // In whole Dai units
+            pause_delay:  60,              // In seconds
+            vow_wait:     3600,            // In seconds
+            vow_dump:     2,               // In whole Dai units
+            vow_sump:     50,              // In whole Dai units
+            vow_bump:     10,              // In whole Dai units
+            vow_hump:     500,             // In whole Dai units
+            cat_box:      10 * THOUSAND,   // In whole Dai units
+            ilk_count:    16               // Num expected in system
         });
 
         //
         // Test for all collateral based changes here
         //
         afterSpell.collaterals["ETH-A"] = CollateralValues({
-            line:         540 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          0 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          150 * RAY / 100,
-            beg:          103 * WAD / 100,
-            ttl:          1 hours,
-            tau:          1 hours,
-            liquidations: 1
+            line:         540 * MILLION,   // In whole Dai units
+            dust:         100,             // In whole Dai units
+            pct:          0,               // In basis points
+            chop:         1300,            // In basis points
+            dunk:         500,             // In whole Dai units
+            mat:          15000,           // In basis points
+            beg:          10300,           // In basis points
+            ttl:          1 hours,         // In seconds
+            tau:          1 hours,         // In seconds
+            liquidations: 1                // 1 if enabled
         });
         afterSpell.collaterals["ETH-B"] = CollateralValues({
-            line:         20 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          6 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          130 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         20 * MILLION,
+            dust:         100,
+            pct:          600,
+            chop:         1300,
+            dunk:         500,
+            mat:          13000,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["BAT-A"] = CollateralValues({
-            line:         5 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          150 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["USDC-A"] = CollateralValues({
-            line:         400 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          101 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         400 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
         });
         afterSpell.collaterals["USDC-B"] = CollateralValues({
-            line:         30 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          50 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          120 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          5000,
+            chop:         1300,
+            dunk:         500,
+            mat:          12000,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
         });
         afterSpell.collaterals["WBTC-A"] = CollateralValues({
-            line:         120 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          150 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         120 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["TUSD-A"] = CollateralValues({
-            line:         50 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          101 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         50 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
         });
         afterSpell.collaterals["KNC-A"] = CollateralValues({
-            line:         5 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["ZRX-A"] = CollateralValues({
-            line:         5 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["MANA-A"] = CollateralValues({
-            line:         1 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          12 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         1 * MILLION,
+            dust:         100,
+            pct:          1200,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["USDT-A"] = CollateralValues({
-            line:         10 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          8 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          150 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          800,
+            chop:         1300,
+            dunk:         500,
+            mat:          15000,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["PAXUSD-A"] = CollateralValues({
-            line:         30 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          4 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          101 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          400,
+            chop:         1300,
+            dunk:         500,
+            mat:          10100,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
         });
         afterSpell.collaterals["COMP-A"] = CollateralValues({
-            line:         7 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          1 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         7 * MILLION,
+            dust:         100,
+            pct:          100,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["LRC-A"] = CollateralValues({
-            line:         3 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          3 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         3 * MILLION,
+            dust:         100,
+            pct:          300,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["LINK-A"] = CollateralValues({
-            line:         5 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          2 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          200,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
         afterSpell.collaterals["BAL-A"] = CollateralValues({
-            line:         4 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          5 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
+            line:         4 * MILLION,
+            dust:         100,
+            pct:          500,
+            chop:         1300,
+            dunk:         500,
+            mat:          17500,
+            beg:          10300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -420,88 +414,122 @@ contract DssSpellTest is DSTest, DSMath {
 
     function checkSystemValues(SystemValues storage values) internal {
         // dsr
-        assertEq(pot.dsr(), values.pot_dsr);
+        uint expectedDSRRate = rates.rates(values.dsr_rate);
         // make sure dsr is less than 100% APR
         // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
         // 1000000021979553151239153027
         assertTrue(
             pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027
         );
-        assertTrue(diffCalc(expectedRate(values.pot_dsrPct), yearlyYield(values.pot_dsr)) <= TOLERANCE);
+        assertTrue(diffCalc(expectedRate(values.dsr_rate), yearlyYield(expectedDSRRate)) <= TOLERANCE);
 
-        // Line
-        assertEq(vat.Line(), values.vat_Line);
+        {
+        // Line values in RAD
+        uint normalizedLine = values.vat_Line * RAD;
+        assertEq(vat.Line(), normalizedLine);
         assertTrue(
             (vat.Line() >= RAD && vat.Line() < 100 * BILLION * RAD) ||
             vat.Line() == 0
         );
+        }
 
         // Pause delay
         assertEq(pause.delay(), values.pause_delay);
 
         // wait
         assertEq(vow.wait(), values.vow_wait);
-
-        // dump
-        assertEq(vow.dump(), values.vow_dump);
+        {
+        // dump values in WAD
+        uint normalizedDump = values.vow_dump * WAD;
+        assertEq(vow.dump(), normalizedDump);
         assertTrue(
             (vow.dump() >= WAD && vow.dump() < 2 * THOUSAND * WAD) ||
             vow.dump() == 0
         );
-
-        // sump
-        assertEq(vow.sump(), values.vow_sump);
+        }
+        {
+        // sump values in RAD
+        uint normalizedSump = values.vow_sump * RAD;
+        assertEq(vow.sump(), normalizedSump);
         assertTrue(
             (vow.sump() >= RAD && vow.sump() < 500 * THOUSAND * RAD) ||
             vow.sump() == 0
         );
-
-        // bump
-        assertEq(vow.bump(), values.vow_bump);
+        }
+        {
+        // bump values in RAD
+        uint normalizedBump = values.vow_bump * RAD;
+        assertEq(vow.bump(), normalizedBump);
         assertTrue(
             (vow.bump() >= RAD && vow.bump() < HUNDRED * THOUSAND * RAD) ||
             vow.bump() == 0
         );
-
-        // hump
-        assertEq(vow.hump(), values.vow_hump);
+        }
+        {
+        // hump values in RAD
+        uint normalizedHump = values.vow_hump * RAD;
+        assertEq(vow.hump(), normalizedHump);
         assertTrue(
             (vow.hump() >= RAD && vow.hump() < HUNDRED * MILLION * RAD) ||
             vow.hump() == 0
         );
+        }
+
+        // box values in RAD
+        {
+            uint normalizedBox = values.cat_box * RAD;
+            assertEq(cat.box(), normalizedBox);
+        }
+
+        // check number of ilks
+        assertEq(reg.count(), values.ilk_count);
+
     }
 
     function checkCollateralValues(bytes32 ilk, SystemValues storage values) internal {
         (uint duty,)  = jug.ilks(ilk);
-        assertEq(duty, rates.rates(values.collaterals[ilk].pct / 10));
+        assertEq(duty, rates.rates(values.collaterals[ilk].pct));
         // make sure duty is less than 1000% APR
         // bc -l <<< 'scale=27; e( l(10.00)/(60 * 60 * 24 * 365) )'
         // 1000000073014496989316680335
         assertTrue(duty >= RAY && duty < 1000000073014496989316680335);  // gt 0 and lt 1000%
-        assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct / 10))) <= TOLERANCE);
+        assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct))) <= TOLERANCE);
         assertTrue(values.collaterals[ilk].pct < THOUSAND * THOUSAND);   // check value lt 1000%
-
+        {
         (,,, uint line, uint dust) = vat.ilks(ilk);
-        assertEq(line, values.collaterals[ilk].line);
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestLine = values.collaterals[ilk].line * RAD;
+        assertEq(line, normalizedTestLine);
         assertTrue((line >= RAD && line < BILLION * RAD) || line == 0);  // eq 0 or gt eq 1 RAD and lt 1B
-        assertEq(dust, values.collaterals[ilk].dust);
+        uint normalizedTestDust = values.collaterals[ilk].dust * RAD;
+        assertEq(dust, normalizedTestDust);
         assertTrue((dust >= RAD && dust < 10 * THOUSAND * RAD) || dust == 0); // eq 0 or gt eq 1 and lt 10k
-
+        }
+        {
         (, uint chop, uint dunk) = cat.ilks(ilk);
-        assertEq(chop, values.collaterals[ilk].chop);
+        uint normalizedTestChop = (values.collaterals[ilk].chop * 10**14) + WAD;
+        assertEq(chop, normalizedTestChop);
         // make sure chop is less than 100%
         assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
-        assertEq(dunk, values.collaterals[ilk].dunk);
+        // Convert whole Dai units to expected RAD
+        uint normalizedTestDunk = values.collaterals[ilk].dunk * RAD;
+        assertEq(dunk, normalizedTestDunk);
         // put back in after LIQ-1.2
         assertTrue(dunk >= RAD && dunk < MILLION * RAD);
-
+        }
+        {
         (,uint mat) = spot.ilks(ilk);
-        assertEq(mat, values.collaterals[ilk].mat);
+        // Convert BP to system expected value
+        uint normalizedTestMat = (values.collaterals[ilk].mat * 10**23);
+        assertEq(mat, normalizedTestMat);
         assertTrue(mat >= RAY && mat < 10 * RAY);    // cr eq 100% and lt 1000%
-
+        }
+        {
         (address flipper,,) = cat.ilks(ilk);
         FlipAbstract flip = FlipAbstract(flipper);
-        assertEq(uint(flip.beg()), values.collaterals[ilk].beg);
+        // Convert BP to system expected value
+        uint normalizedTestBeg = values.collaterals[ilk].beg * 10**14;
+        assertEq(uint(flip.beg()), normalizedTestBeg);
         assertTrue(flip.beg() >= WAD && flip.beg() < 105 * WAD / 100);  // gt eq 0% and lt 5%
         assertEq(uint(flip.ttl()), values.collaterals[ilk].ttl);
         assertTrue(flip.ttl() >= 600 && flip.ttl() < 10 hours);         // gt eq 10 minutes and lt 10 hours
@@ -509,6 +537,7 @@ contract DssSpellTest is DSTest, DSMath {
         assertTrue(flip.tau() >= 600 && flip.tau() <= 1 hours);          // gt eq 10 minutes and lt eq 1 hours
 
         assertEq(flip.wards(address(cat)), values.collaterals[ilk].liquidations);  // liquidations == 1 => on
+        }
     }
 
     function testSpellIsCast() public {
@@ -536,73 +565,69 @@ contract DssSpellTest is DSTest, DSMath {
         }
     }
 
-    function testSpellIsCast_TOKEN_INTEGRATION() public {
+    function testSpellIsCast_BAL_INTEGRATION() public {
         vote();
         scheduleWaitAndCast();
         assertTrue(spell.done());
 
-        pipTOKEN.poke();
+        pipBAL.poke();
         hevm.warp(now + 3601);
-        pipTOKEN.poke();
-        spot.poke("TOKEN-LETTER");
-
-        hevm.store(
-            address(TOKEN),
-            keccak256(abi.encode(address(this), uint256(1))),
-            bytes32(uint256(1 * THOUSAND * WAD))
-        );
+        pipBAL.poke();
+        spot.poke("BAL-A");
 
         // Check faucet amount
-        assertEq(faucet.amt(address(TOKEN)), 30 * WAD);
+        uint256 faucetAmount = faucet.amt(address(bal));
+        assertTrue(faucetAmount > 0);
+        faucet.gulp(address(bal));
+        assertEq(bal.balanceOf(address(this)), faucetAmount);
 
         // Check median matches pip.src()
-        assertEq(pipTOKEN.src(), address(medTOKENLETTER));
+        assertEq(pipBAL.src(), address(medBALA));
 
         // Authorization
-        assertEq(joinTOKENLETTER.wards(pauseProxy), 1);
-        assertEq(vat.wards(address(joinTOKENLETTER)), 1);
-        assertEq(flipTOKENLETTER.wards(address(end)), 1);
-        assertEq(flipTOKENLETTER.wards(address(flipMom)), 1);
-        assertEq(pipTOKEN.wards(address(osmMom)), 1);
-        assertEq(pipTOKEN.bud(address(spot)), 1);
-        assertEq(pipTOKEN.bud(address(end)), 1);
-        assertEq(MedianAbstract(pipTOKEN.src()).bud(address(pipTOKEN)), 1);
+        assertEq(joinBALA.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(joinBALA)), 1);
+        assertEq(flipBALA.wards(address(end)), 1);
+        assertEq(flipBALA.wards(address(flipMom)), 1);
+        assertEq(pipBAL.wards(address(osmMom)), 1);
+        assertEq(pipBAL.bud(address(spot)), 1);
+        assertEq(pipBAL.bud(address(end)), 1);
+        assertEq(MedianAbstract(pipBAL.src()).bud(address(pipBAL)), 1);
 
         // Join to adapter
-        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
-        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
-        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
-        assertEq(token.balanceOf(address(this)), 0);
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("BAL-A", address(this)), 0);
+        bal.approve(address(joinBALA), faucetAmount);
+        joinBALA.join(address(this), faucetAmount);
+        assertEq(bal.balanceOf(address(this)), 0);
+        assertEq(vat.gem("BAL-A", address(this)), faucetAmount);
 
         // Deposit collateral, generate DAI
         assertEq(vat.dai(address(this)), 0);
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(100 * WAD));
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        vat.frob("BAL-A", address(this), address(this), address(this), int(faucetAmount), int(100 * WAD));
+        assertEq(vat.gem("BAL-A", address(this)), 0);
         assertEq(vat.dai(address(this)), 100 * RAD);
 
         // Payback DAI, withdraw collateral
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), -int(1 * THOUSAND * WAD), -int(100 * WAD));
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        vat.frob("BAL-A", address(this), address(this), address(this), -int(faucetAmount), -int(100 * WAD));
+        assertEq(vat.gem("BAL-A", address(this)), faucetAmount);
         assertEq(vat.dai(address(this)), 0);
 
         // Withdraw from adapter
-        joinTOKENLETTER.exit(address(this), 1 * THOUSAND * WAD);
-        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        joinBALA.exit(address(this), faucetAmount);
+        assertEq(bal.balanceOf(address(this)), faucetAmount);
+        assertEq(vat.gem("BAL-A", address(this)), 0);
 
         // Generate new DAI to force a liquidation
-        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
-        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
-        (,,uint256 spotV,,) = vat.ilks("TOKEN-LETTER");
+        bal.approve(address(joinBALA), faucetAmount);
+        joinBALA.join(address(this), faucetAmount);
+        (,,uint256 spotV,,) = vat.ilks("BAL-A");
         // dart max amount of DAI
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(mul(1 * THOUSAND * WAD, spotV) / RAY));
+        vat.frob("BAL-A", address(this), address(this), address(this), int(faucetAmount), int(mul(faucetAmount, spotV) / RAY));
         hevm.warp(now + 1);
-        jug.drip("TOKEN-LETTER");
-        assertEq(flipTOKENLETTER.kicks(), 0);
-        cat.bite("TOKEN-LETTER", address(this));
-        assertEq(flipTOKENLETTER.kicks(), 1);
+        jug.drip("BAL-A");
+        assertEq(flipBALA.kicks(), 0);
+        cat.bite("BAL-A", address(this));
+        assertEq(flipBALA.kicks(), 1);
     }
 
 }

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -95,6 +95,13 @@ contract DssSpellTest is DSTest, DSMath {
     FlipAbstract     flipLINKA = FlipAbstract(       0xfbDCDF5Bd98f68cEfc3f37829189b97B602eCFF2);
     MedianAbstract    medLINKA = MedianAbstract(     0x7cb395DF9f1534cF528470e2F1AE2D1867d6253f);
 
+    // BAL-A specific
+    DSTokenAbstract       bal = DSTokenAbstract(     0x630D82Cbf82089B09F71f8d3aAaff2EBA6f47B15);
+    GemJoinAbstract  joinBALA = GemJoinAbstract(     0x17D3fd747FCc1BA15DC07f077ccd5Fc1902e0F08);
+    OsmAbstract        pipBAL = OsmAbstract(         0x4fd34872F3AbC07ea6C45c7907f87041C0801DdE);
+    FlipAbstract     flipBALA = FlipAbstract(        0xF6d19CC05482Ef7F73f09c1031BA01567EF6ac0f);
+    MedianAbstract    medBALA = MedianAbstract(      0x0C472661dde5B08BEee6a7F8266720ea445830a3);
+
     // Faucet
     FaucetAbstract      faucet = FaucetAbstract(     0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3);
 
@@ -364,6 +371,18 @@ contract DssSpellTest is DSTest, DSMath {
             tau:          1 hours,
             liquidations: 1
         });
+        afterSpell.collaterals["BAL-A"] = CollateralValues({
+            line:         4 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          5 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         500 * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
     }
 
     function vote() private {
@@ -517,7 +536,73 @@ contract DssSpellTest is DSTest, DSMath {
         }
     }
 
-    function testRatesDeployCost() public {
-        new Rates();
+    function testSpellIsCast_TOKEN_INTEGRATION() public {
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        pipTOKEN.poke();
+        hevm.warp(now + 3601);
+        pipTOKEN.poke();
+        spot.poke("TOKEN-LETTER");
+
+        hevm.store(
+            address(TOKEN),
+            keccak256(abi.encode(address(this), uint256(1))),
+            bytes32(uint256(1 * THOUSAND * WAD))
+        );
+
+        // Check faucet amount
+        assertEq(faucet.amt(address(TOKEN)), 30 * WAD);
+
+        // Check median matches pip.src()
+        assertEq(pipTOKEN.src(), address(medTOKENLETTER));
+
+        // Authorization
+        assertEq(joinTOKENLETTER.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(joinTOKENLETTER)), 1);
+        assertEq(flipTOKENLETTER.wards(address(end)), 1);
+        assertEq(flipTOKENLETTER.wards(address(flipMom)), 1);
+        assertEq(pipTOKEN.wards(address(osmMom)), 1);
+        assertEq(pipTOKEN.bud(address(spot)), 1);
+        assertEq(pipTOKEN.bud(address(end)), 1);
+        assertEq(MedianAbstract(pipTOKEN.src()).bud(address(pipTOKEN)), 1);
+
+        // Join to adapter
+        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
+        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+
+        // Deposit collateral, generate DAI
+        assertEq(vat.dai(address(this)), 0);
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(100 * WAD));
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        assertEq(vat.dai(address(this)), 100 * RAD);
+
+        // Payback DAI, withdraw collateral
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), -int(1 * THOUSAND * WAD), -int(100 * WAD));
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.dai(address(this)), 0);
+
+        // Withdraw from adapter
+        joinTOKENLETTER.exit(address(this), 1 * THOUSAND * WAD);
+        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+
+        // Generate new DAI to force a liquidation
+        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
+        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        (,,uint256 spotV,,) = vat.ilks("TOKEN-LETTER");
+        // dart max amount of DAI
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(mul(1 * THOUSAND * WAD, spotV) / RAY));
+        hevm.warp(now + 1);
+        jug.drip("TOKEN-LETTER");
+        assertEq(flipTOKENLETTER.kicks(), 0);
+        cat.bite("TOKEN-LETTER", address(this));
+        assertEq(flipTOKENLETTER.kicks(), 1);
     }
+
 }

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -14,9 +14,11 @@ interface Hevm {
 
 contract DssSpellTest is DSTest, DSMath {
     // populate with kovan spell if needed
-    address constant KOVAN_SPELL = address(0);
+    address constant KOVAN_SPELL = address(
+      0x0DE068b775ED97f53981a733769146Aba3F4a1aC
+    );
     // this needs to be updated
-    uint256 constant SPELL_CREATED = 1602770824;
+    uint256 constant SPELL_CREATED = 1603315220;
 
     struct CollateralValues {
         uint256 line;

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -192,7 +192,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,            // In basis points
             dunk:         500,             // In whole Dai units
             mat:          15000,           // In basis points
-            beg:          10300,           // In basis points
+            beg:          300,             // In basis points
             ttl:          1 hours,         // In seconds
             tau:          1 hours,         // In seconds
             liquidations: 1                // 1 if enabled
@@ -204,7 +204,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          13000,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -216,7 +216,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          15000,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -228,7 +228,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          10100,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
@@ -240,7 +240,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          12000,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
@@ -252,7 +252,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          15000,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -264,7 +264,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          10100,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
@@ -276,7 +276,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -288,7 +288,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -300,7 +300,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -312,7 +312,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          15000,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -324,7 +324,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          10100,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 0
@@ -336,7 +336,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -348,7 +348,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -360,7 +360,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -372,7 +372,7 @@ contract DssSpellTest is DSTest, DSMath {
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
@@ -528,7 +528,7 @@ contract DssSpellTest is DSTest, DSMath {
         (address flipper,,) = cat.ilks(ilk);
         FlipAbstract flip = FlipAbstract(flipper);
         // Convert BP to system expected value
-        uint normalizedTestBeg = values.collaterals[ilk].beg * 10**14;
+        uint normalizedTestBeg = (values.collaterals[ilk].beg + 10000)  * 10**14;
         assertEq(uint(flip.beg()), normalizedTestBeg);
         assertTrue(flip.beg() >= WAD && flip.beg() < 105 * WAD / 100);  // gt eq 0% and lt 5%
         assertEq(uint(flip.ttl()), values.collaterals[ilk].ttl);

--- a/template/SpellAction.sol
+++ b/template/SpellAction.sol
@@ -8,6 +8,7 @@ contract SpellAction {
     address constant FLIPPER_MOM = ;
     address constant OSM_MOM = ; // Only if PIP_TOKEN = Osm
     address constant ILK_REGISTRY = ;
+    address constant FAUCET = ;
 
     address constant TOKEN = ;
     address constant MCD_JOIN_TOKEN_LETTER = ;
@@ -106,5 +107,8 @@ contract SpellAction {
 
         // Add new ilk to the IlkRegistry
         IlkRegistryAbstract(ILK_REGISTRY).add(MCD_JOIN_TOKEN_LETTER);
+
+        // Set gulp amount in faucet on kovan (only use WAD for decimals = 18)
+        FaucetAbstract(FAUCET).setAmt(TOKEN, X * WAD);
     }
 }

--- a/template/SpellAction.t.sol
+++ b/template/SpellAction.t.sol
@@ -1,0 +1,94 @@
+    // add a TOKEN-LETTER specific section with the correct addressess
+    DSTokenAbstract            token = DSTokenAbstract();
+    GemJoinAbstract  joinTOKENLETTER = GemJoinAbstract();
+    OsmAbstract             pipTOKEN = OsmAbstract();
+    FlipAbstract     flipTOKENLETTER = FlipAbstract();
+    MedianAbstract    medTOKENLETTER = MedianAbstract();
+
+        // add to the end of the list of collateral tests
+        // change the values as appropriate
+        afterSpell.collaterals["TOKEN-LETTER"] = CollateralValues({
+            line:         4 * MILLION * RAD,
+            dust:         100 * RAD,
+            pct:          5 * 1000,
+            chop:         113 * WAD / 100,
+            dunk:         500 * RAD,
+            mat:          175 * RAY / 100,
+            beg:          103 * WAD / 100,
+            ttl:          1 hours,
+            tau:          1 hours,
+            liquidations: 1
+        });
+
+    // this will tests a new collateral addition. Reaplace all occurences
+    // of TOKEN with the appropriate collateral, and LETTER with the appropriate
+    // letter.  Also replace lowercase token with the appropriate letter.
+    function testSpellIsCast_TOKEN_INTEGRATION() public {
+        vote();
+        scheduleWaitAndCast();
+        assertTrue(spell.done());
+
+        pipTOKEN.poke();
+        hevm.warp(now + 3601);
+        pipTOKEN.poke();
+        spot.poke("TOKEN-LETTER");
+
+        hevm.store(
+            address(TOKEN),
+            keccak256(abi.encode(address(this), uint256(1))),
+            bytes32(uint256(1 * THOUSAND * WAD))
+        );
+
+        // Check faucet amount
+        assertEq(faucet.amt(address(TOKEN)), 30 * WAD);
+
+        // Check median matches pip.src()
+        assertEq(pipTOKEN.src(), address(medTOKENLETTER));
+
+        // Authorization
+        assertEq(joinTOKENLETTER.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(joinTOKENLETTER)), 1);
+        assertEq(flipTOKENLETTER.wards(address(end)), 1);
+        assertEq(flipTOKENLETTER.wards(address(flipMom)), 1);
+        assertEq(pipTOKEN.wards(address(osmMom)), 1);
+        assertEq(pipTOKEN.bud(address(spot)), 1);
+        assertEq(pipTOKEN.bud(address(end)), 1);
+        assertEq(MedianAbstract(pipTOKEN.src()).bud(address(pipTOKEN)), 1);
+
+        // Join to adapter
+        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
+        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+
+        // Deposit collateral, generate DAI
+        assertEq(vat.dai(address(this)), 0);
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(100 * WAD));
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+        assertEq(vat.dai(address(this)), 100 * RAD);
+
+        // Payback DAI, withdraw collateral
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), -int(1 * THOUSAND * WAD), -int(100 * WAD));
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.dai(address(this)), 0);
+
+        // Withdraw from adapter
+        joinTOKENLETTER.exit(address(this), 1 * THOUSAND * WAD);
+        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
+
+        // Generate new DAI to force a liquidation
+        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
+        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        (,,uint256 spotV,,) = vat.ilks("TOKEN-LETTER");
+        // dart max amount of DAI
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(mul(1 * THOUSAND * WAD, spotV) / RAY));
+        hevm.warp(now + 1);
+        jug.drip("TOKEN-LETTER");
+        assertEq(flipTOKENLETTER.kicks(), 0);
+        cat.bite("TOKEN-LETTER", address(this));
+        assertEq(flipTOKENLETTER.kicks(), 1);
+    }
+

--- a/template/SpellAction.t.sol
+++ b/template/SpellAction.t.sol
@@ -8,14 +8,10 @@
         // add to the end of the list of collateral tests
         // change the values as appropriate
         afterSpell.collaterals["TOKEN-LETTER"] = CollateralValues({
-            line:         4 * MILLION * RAD,
-            dust:         100 * RAD,
-            pct:          5 * 1000,
-            chop:         113 * WAD / 100,
-            dunk:         500 * RAD,
-            mat:          175 * RAY / 100,
-            beg:          103 * WAD / 100,
-            ttl:          1 hours,
+            line:         4 * MILLION,                                                          dust:         100,
+            pct:          500,                                                                  chop:         1300,
+            dunk:         500,                                                                  mat:          17500,
+            beg:          10300,                                                                ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1
         });
@@ -33,14 +29,11 @@
         pipTOKEN.poke();
         spot.poke("TOKEN-LETTER");
 
-        hevm.store(
-            address(TOKEN),
-            keccak256(abi.encode(address(this), uint256(1))),
-            bytes32(uint256(1 * THOUSAND * WAD))
-        );
-
         // Check faucet amount
-        assertEq(faucet.amt(address(TOKEN)), 30 * WAD);
+        uint256 faucetAmount = faucet.amt(address(token));
+        assertTrue(faucetAmount > 0);
+        faucet.gulp(address(token));
+        assertEq(token.balanceOf(address(this)), faucetAmount);
 
         // Check median matches pip.src()
         assertEq(pipTOKEN.src(), address(medTOKENLETTER));
@@ -56,35 +49,34 @@
         assertEq(MedianAbstract(pipTOKEN.src()).bud(address(pipTOKEN)), 1);
 
         // Join to adapter
-        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
         assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
-        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
-        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        token.approve(address(joinTOKENLETTER), faucetAmount);
+        joinTOKENLETTER.join(address(this), faucetAmount);
         assertEq(token.balanceOf(address(this)), 0);
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), faucetAmount);
 
         // Deposit collateral, generate DAI
         assertEq(vat.dai(address(this)), 0);
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(100 * WAD));
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(faucetAmount), int(100 * WAD));
         assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
         assertEq(vat.dai(address(this)), 100 * RAD);
 
         // Payback DAI, withdraw collateral
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), -int(1 * THOUSAND * WAD), -int(100 * WAD));
-        assertEq(vat.gem("TOKEN-LETTER", address(this)), 1 * THOUSAND * WAD);
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), -int(faucetAmount), -int(100 * WAD));
+        assertEq(vat.gem("TOKEN-LETTER", address(this)), faucetAmount);
         assertEq(vat.dai(address(this)), 0);
 
         // Withdraw from adapter
-        joinTOKENLETTER.exit(address(this), 1 * THOUSAND * WAD);
-        assertEq(token.balanceOf(address(this)), 1 * THOUSAND * WAD);
+        joinTOKENLETTER.exit(address(this), faucetAmount);
+        assertEq(token.balanceOf(address(this)), faucetAmount);
         assertEq(vat.gem("TOKEN-LETTER", address(this)), 0);
 
         // Generate new DAI to force a liquidation
-        token.approve(address(joinTOKENLETTER), 1 * THOUSAND * WAD);
-        joinTOKENLETTER.join(address(this), 1 * THOUSAND * WAD);
+        token.approve(address(joinTOKENLETTER), faucetAmount);
+        joinTOKENLETTER.join(address(this), faucetAmount);
         (,,uint256 spotV,,) = vat.ilks("TOKEN-LETTER");
         // dart max amount of DAI
-        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(1 * THOUSAND * WAD), int(mul(1 * THOUSAND * WAD, spotV) / RAY));
+        vat.frob("TOKEN-LETTER", address(this), address(this), address(this), int(faucetAmount), int(mul(faucetAmount, spotV) / RAY));
         hevm.warp(now + 1);
         jug.drip("TOKEN-LETTER");
         assertEq(flipTOKENLETTER.kicks(), 0);

--- a/template/SpellAction.t.sol
+++ b/template/SpellAction.t.sol
@@ -14,7 +14,7 @@
             chop:         1300,
             dunk:         500,
             mat:          17500,
-            beg:          10300,
+            beg:          300,
             ttl:          1 hours,
             tau:          1 hours,
             liquidations: 1


### PR DESCRIPTION
# Description

Spell Description:

Adds BAL-A to kovan

COB Team Name or Author(s): @hexonaut @godsflaw 

# Contribution Checklist

- [x] Code approved
- [x] Tests approved
- [x] CI Tests pass

# Checklist

- [x] Every contract variable/method declared as public/external private/internal
- [x] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
- [x] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [x] Validate all addresses used are in Kovan changelog
- [x] Deploy spell to kovan `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.5.12 --network kovan build --extract && dapp create DssSpell --verify --network kovan --gas=XXX --gas-price="$(seth --to-wei YYY "gwei")"`
- [x] Ensure contract is verified on `kovan` etherscan
- [x] Change test to use kovan spell address and deploy timestamp
- [x] Keep `Kovan-DssSpell.sol` and `Kovan-DssSpell.t.sol` the same, but make a copy in `archive`
- [x] `squash and merge` this PR
