### PR TITLE
SC-11420 Clipper for YFI-A

### DIFF
--- a/archive/2021-04-22-Add-YFI-Clipper-Add-Lerp-Surplus.sol
+++ b/archive/2021-04-22-Add-YFI-Clipper-Add-Lerp-Surplus.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Maker Ecosystem Growth Holdings, INC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.12;
+
+import {Fileable, ChainlogLike} from "dss-exec-lib/DssExecLib.sol";
+import "dss-exec-lib/DssExec.sol";
+import "dss-exec-lib/DssAction.sol";
+import "dss-interfaces/dss/ClipAbstract.sol";
+import "dss-interfaces/dss/ClipperMomAbstract.sol";
+import "dss-interfaces/dss/VowAbstract.sol";
+
+interface LerpFabLike {
+    function newLerp(bytes32, address, bytes32, uint256, uint256, uint256, uint256) external returns (address);
+    function active(uint256) external returns (address);
+    function lerps(bytes32) external returns (address);
+    function tall() external;
+    function count() external returns (uint256);
+}
+
+contract DssSpellAction is DssAction {
+
+    string public constant description = "Kovan Spell";
+
+    // Turn off office hours
+    function officeHours() public override returns (bool) {
+        return false;
+    }
+
+    uint256 constant WAD = 10**18;
+    uint256 constant RAY = 10**27;
+    uint256 constant RAD = 10**45;
+
+    address constant MCD_CLIP_YFI_A      = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2; 
+    address constant MCD_CLIP_CALC_YFI_A = 0x54A18C6ceEBDf42D8532EBf5e0a67C430a51b2f6;
+
+    address constant LERP_FAB = 0xa6766Ed3574bAFc6114618E74035C7bb5e9a6aa9;
+
+    function actions() public override {
+        address MCD_VAT = DssExecLib.vat();
+        address MCD_CAT = DssExecLib.cat();
+        address MCD_DOG = DssExecLib.getChangelogAddress("MCD_DOG");
+        address MCD_VOW = DssExecLib.vow();
+        address MCD_END = DssExecLib.end();
+        address MCD_ESM = DssExecLib.getChangelogAddress("MCD_ESM");
+        address CLIPPER_MOM = DssExecLib.getChangelogAddress("CLIPPER_MOM");
+        address ILK_REGISTRY = DssExecLib.getChangelogAddress("ILK_REGISTRY");
+        address PIP_YFI = DssExecLib.getChangelogAddress("PIP_YFI");
+        address MCD_FLIP_YFI_A = DssExecLib.getChangelogAddress("MCD_FLIP_YFI_A");
+
+        // Set CLIP for YFI-A in the DOG
+        DssExecLib.setContract(MCD_DOG, "YFI-A", "clip", MCD_CLIP_YFI_A);
+
+        // Set VOW in the YFI-A CLIP
+        DssExecLib.setContract(MCD_CLIP_YFI_A, "vow", MCD_VOW);
+
+        // Set CALC in the YFI-A CLIP
+        DssExecLib.setContract(MCD_CLIP_YFI_A, "calc", MCD_CLIP_CALC_YFI_A);
+
+        // Authorize CLIP can access to VAT
+        DssExecLib.authorize(MCD_VAT, MCD_CLIP_YFI_A);
+
+        // Authorize CLIP can access to DOG
+        DssExecLib.authorize(MCD_DOG, MCD_CLIP_YFI_A);
+
+        // Authorize DOG can kick auctions on CLIP
+        DssExecLib.authorize(MCD_CLIP_YFI_A, MCD_DOG);
+
+        // Authorize the new END to access the YFI CLIP
+        DssExecLib.authorize(MCD_CLIP_YFI_A, MCD_END);
+
+        // Authorize CLIPPERMOM can set the stopped flag in CLIP
+        DssExecLib.authorize(MCD_CLIP_YFI_A, CLIPPER_MOM);
+
+        // Authorize new ESM to execute in YFI-A Clipper
+        DssExecLib.authorize(MCD_CLIP_YFI_A, MCD_ESM);
+
+        // Whitelist CLIP in the YFI osm
+        DssExecLib.addReaderToOSMWhitelist(PIP_YFI, MCD_CLIP_YFI_A);
+
+        // Whitelist CLIPPER_MOM in the YFI osm
+        DssExecLib.addReaderToOSMWhitelist(PIP_YFI, CLIPPER_MOM);
+
+        // No more auctions kicked via the CAT:
+        DssExecLib.deauthorize(MCD_FLIP_YFI_A, MCD_CAT);
+
+        // No more circuit breaker for the FLIP in YFI-A:
+        DssExecLib.deauthorize(MCD_FLIP_YFI_A, DssExecLib.flipperMom());
+
+        Fileable(MCD_DOG).file("YFI-A", "hole", 5_000 * RAD);
+        Fileable(MCD_DOG).file("YFI-A", "chop", 113 * WAD / 100);
+        Fileable(MCD_CLIP_YFI_A).file("buf", 130 * RAY / 100);
+        Fileable(MCD_CLIP_YFI_A).file("tail", 140 minutes);
+        Fileable(MCD_CLIP_YFI_A).file("cusp", 40 * RAY / 100);
+        Fileable(MCD_CLIP_YFI_A).file("chip", 1 * WAD / 1000);
+        Fileable(MCD_CLIP_YFI_A).file("tip", 0);
+        Fileable(MCD_CLIP_CALC_YFI_A).file("cut", 99 * RAY / 100); // 1% cut
+        Fileable(MCD_CLIP_CALC_YFI_A).file("step", 90 seconds);
+
+        //  Tolerance currently set to 50%.
+        //   n.b. 600000000000000000000000000 == 40% acceptable drop
+        ClipperMomAbstract(CLIPPER_MOM).setPriceTolerance(MCD_CLIP_YFI_A, 50 * RAY / 100);
+
+        ClipAbstract(MCD_CLIP_YFI_A).upchost();
+
+        // Increase the Surplus Buffer to 1000 DAI over 7 days starting Thu Apr 22 2021 16:00:00 GMT+0000
+        address lerp = LerpFabLike(LERP_FAB).newLerp("20210421_VOW_HUMP1", MCD_VOW, "hump", 1619107200, 500 * RAD, 1000 * RAD, 7 days);
+        VowAbstract(MCD_VOW).rely(lerp);
+
+        // Replace flip to clip in the ilk registry
+        DssExecLib.setContract(ILK_REGISTRY, "YFI-A", "xlip", MCD_CLIP_YFI_A);
+        Fileable(ILK_REGISTRY).file("YFI-A", "class", 1);
+
+        address log = DssExecLib.getChangelogAddress("CHANGELOG");
+        DssExecLib.setChangelogAddress("MCD_CLIP_YFI_A", MCD_CLIP_YFI_A);
+        DssExecLib.setChangelogAddress("MCD_CLIP_CALC_YFI_A", MCD_CLIP_CALC_YFI_A);
+        ChainlogLike(log).removeAddress("MCD_FLIP_YFI_A");
+
+        DssExecLib.setChangelogAddress("LERP_FAB", LERP_FAB);
+
+        DssExecLib.setChangelogVersion("1.4.0");
+    }
+}
+
+contract DssSpell is DssExec {
+    DssSpellAction internal action_ = new DssSpellAction();
+    constructor() DssExec(action_.description(), block.timestamp + 30 days, address(action_)) public {}
+}

--- a/archive/2021-04-22-Add-YFI-Clipper-Add-Lerp-Surplus.t.sol
+++ b/archive/2021-04-22-Add-YFI-Clipper-Add-Lerp-Surplus.t.sol
@@ -1,0 +1,1920 @@
+pragma solidity 0.6.12;
+
+import "ds-math/math.sol";
+import "ds-test/test.sol";
+import "lib/dss-interfaces/src/Interfaces.sol";
+import "./test/rates.sol";
+import "./test/addresses_kovan.sol";
+
+import {DssSpell, LerpFabLike} from "./Kovan-DssSpell.sol";
+
+interface Hevm {
+    function warp(uint) external;
+    function store(address,bytes32,bytes32) external;
+    function load(address,bytes32) external view returns (bytes32);
+}
+
+interface SpellLike {
+    function done() external view returns (bool);
+    function cast() external;
+}
+
+// Specific for this spell
+interface ManagerLike {
+    function dai() external view returns (address);
+    function daiJoin() external view returns (address);
+    function end() external view returns (address);
+    function gem() external view returns (address);
+    function owner() external view returns (address);
+    function urn() external view returns (address);
+    function vat() external view returns (address);
+    function vow() external view returns (address);
+    function draw(uint256) external;
+    function exit(uint256) external;
+    function join(uint256) external;
+    function lock(uint256) external;
+    function wipe(uint256) external;
+    function file(bytes32, address) external;
+}
+
+interface Root {
+    function relyContract(address, address) external;
+}
+
+interface Memberlist {
+    function updateMember(address, uint) external;
+}
+
+interface DropToken is DSTokenAbstract {
+    function memberlist() external view returns (address);
+}
+
+interface LerpLike {
+    function tick() external;
+}
+
+//
+
+contract DssSpellTest is DSTest, DSMath {
+
+    struct SpellValues {
+        address deployed_spell;
+        uint256 deployed_spell_created;
+        address previous_spell;
+        uint256 previous_spell_execution_time;
+        bool    office_hours_enabled;
+        uint256 expiration_threshold;
+    }
+
+    struct CollateralValues {
+        bool aL_enabled;
+        uint256 aL_line;
+        uint256 aL_gap;
+        uint256 aL_ttl;
+        uint256 line;
+        uint256 dust;
+        uint256 pct;
+        uint256 mat;
+        bytes32 liqType;
+        bool    liqOn;
+        uint256 chop;
+        uint256 cat_dunk;
+        uint256 flip_beg;
+        uint48  flip_ttl;
+        uint48  flip_tau;
+        uint256 flipper_mom;
+        uint256 dog_hole;
+        uint256 clip_buf;
+        uint256 clip_tail;
+        uint256 clip_cusp;
+        uint256 clip_chip;
+        uint256 clip_tip;
+        uint256 clipper_mom;
+        uint256 calc_tau;
+        uint256 calc_step;
+        uint256 calc_cut;
+    }
+
+    struct SystemValues {
+        uint256 pot_dsr;
+        uint256 pause_delay;
+        uint256 vow_wait;
+        uint256 vow_dump;
+        uint256 vow_sump;
+        uint256 vow_bump;
+        uint256 vow_hump;
+        uint256 flap_beg;
+        uint256 flap_ttl;
+        uint256 flap_tau;
+        uint256 cat_box;
+        uint256 dog_Hole;
+        address pause_authority;
+        address osm_mom_authority;
+        address flipper_mom_authority;
+        address clipper_mom_authority;
+        uint256 ilk_count;
+        mapping (bytes32 => CollateralValues) collaterals;
+    }
+
+    SystemValues afterSpell;
+    SpellValues  spellValues;
+
+    Hevm hevm;
+    Rates     rates = new Rates();
+    Addresses addr  = new Addresses();
+
+    // KOVAN ADDRESSES
+    DSPauseAbstract        pause = DSPauseAbstract(    addr.addr("MCD_PAUSE"));
+    address           pauseProxy =                     addr.addr("MCD_PAUSE_PROXY");
+    DSChiefAbstract        chief = DSChiefAbstract(    addr.addr("MCD_ADM"));
+    VatAbstract              vat = VatAbstract(        addr.addr("MCD_VAT"));
+    VowAbstract              vow = VowAbstract(        addr.addr("MCD_VOW"));
+    CatAbstract              cat = CatAbstract(        addr.addr("MCD_CAT"));
+    DogAbstract              dog = DogAbstract(        addr.addr("MCD_DOG"));
+    PotAbstract              pot = PotAbstract(        addr.addr("MCD_POT"));
+    JugAbstract              jug = JugAbstract(        addr.addr("MCD_JUG"));
+    SpotAbstract         spotter = SpotAbstract(       addr.addr("MCD_SPOT"));
+    DaiAbstract              dai = DaiAbstract(        addr.addr("MCD_DAI"));
+    DaiJoinAbstract      daiJoin = DaiJoinAbstract(    addr.addr("MCD_JOIN_DAI"));
+    DSTokenAbstract          gov = DSTokenAbstract(    addr.addr("MCD_GOV"));
+    EndAbstract              end = EndAbstract(        addr.addr("MCD_END"));
+    ESMAbstract              esm = ESMAbstract(        addr.addr("MCD_ESM"));
+    IlkRegistryAbstract      reg = IlkRegistryAbstract(addr.addr("ILK_REGISTRY"));
+    FlapAbstract            flap = FlapAbstract(       addr.addr("MCD_FLAP"));
+
+    OsmMomAbstract        osmMom = OsmMomAbstract(     addr.addr("OSM_MOM"));
+    FlipperMomAbstract   flipMom = FlipperMomAbstract( addr.addr("FLIPPER_MOM"));
+    ClipperMomAbstract   clipMom = ClipperMomAbstract( addr.addr("CLIPPER_MOM"));
+    DssAutoLineAbstract autoLine = DssAutoLineAbstract(addr.addr("MCD_IAM_AUTO_LINE"));
+
+    // Specific for this spell
+    EndAbstract          end_old = EndAbstract(0x0D1a98E93d9cE32E44bC035e8C6E4209fdB70C27);
+    ESMAbstract          esm_old = ESMAbstract(0x23Aa7cbeb266413f968D284acce3a3f9EEFFC2Ec);
+
+    // Faucet
+    FaucetAbstract        faucet = FaucetAbstract(     addr.addr("FAUCET"));
+
+    DssSpell spell;
+
+    // CHEAT_CODE = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D
+    bytes20 constant CHEAT_CODE =
+        bytes20(uint160(uint256(keccak256('hevm cheat code'))));
+
+    uint256 constant HUNDRED    = 10 ** 2;
+    uint256 constant THOUSAND   = 10 ** 3;
+    uint256 constant MILLION    = 10 ** 6;
+    uint256 constant BILLION    = 10 ** 9;
+    uint256 constant RAD        = 10 ** 45;
+
+    uint256 constant monthly_expiration = 4 days;
+    uint256 constant weekly_expiration = 30 days;
+
+    event Debug(uint256 index, uint256 val);
+    event Debug(uint256 index, address addr);
+    event Debug(uint256 index, bytes32 what);
+    event Log(string message, address deployer, string contractName);
+
+    // Many of the settings that change weekly rely on the rate accumulator
+    // described at https://docs.makerdao.com/smart-contract-modules/rates-module
+    // To check this yourself, use the following rate calculation (example 8%):
+    //
+    // $ bc -l <<< 'scale=27; e( l(1.01)/(60 * 60 * 24 * 365) )'
+    //
+    // Rates table is in ./test/rates.sol
+
+    // not provided in DSMath
+    function rpow(uint x, uint n, uint b) internal pure returns (uint z) {
+      assembly {
+        switch x case 0 {switch n case 0 {z := b} default {z := 0}}
+        default {
+          switch mod(n, 2) case 0 { z := b } default { z := x }
+          let half := div(b, 2)  // for rounding.
+          for { n := div(n, 2) } n { n := div(n,2) } {
+            let xx := mul(x, x)
+            if iszero(eq(div(xx, x), x)) { revert(0,0) }
+            let xxRound := add(xx, half)
+            if lt(xxRound, xx) { revert(0,0) }
+            x := div(xxRound, b)
+            if mod(n,2) {
+              let zx := mul(z, x)
+              if and(iszero(iszero(x)), iszero(eq(div(zx, x), z))) { revert(0,0) }
+              let zxRound := add(zx, half)
+              if lt(zxRound, zx) { revert(0,0) }
+              z := div(zxRound, b)
+            }
+          }
+        }
+      }
+    }
+    function divup(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = add(x, sub(y, 1)) / y;
+    }
+    // 10^-5 (tenth of a basis point) as a RAY
+    uint256 TOLERANCE = 10 ** 22;
+
+    function yearlyYield(uint256 duty) public pure returns (uint256) {
+        return rpow(duty, (365 * 24 * 60 *60), RAY);
+    }
+
+    function expectedRate(uint256 percentValue) public pure returns (uint256) {
+        return (10000 + percentValue) * (10 ** 23);
+    }
+
+    function diffCalc(uint256 expectedRate_, uint256 yearlyYield_) public pure returns (uint256) {
+        return (expectedRate_ > yearlyYield_) ? expectedRate_ - yearlyYield_ : yearlyYield_ - expectedRate_;
+    }
+
+    function castPreviousSpell() internal {
+        SpellLike prevSpell = SpellLike(spellValues.previous_spell);
+        // warp and cast previous spell so values are up-to-date to test against
+        if (prevSpell != SpellLike(0) && !prevSpell.done()) {
+            hevm.warp(spellValues.previous_spell_execution_time);
+            prevSpell.cast();
+        }
+    }
+
+    function setUp() public {
+        hevm = Hevm(address(CHEAT_CODE));
+
+        //
+        // Test for spell-specific parameters
+        //
+        spellValues = SpellValues({
+            deployed_spell:                 0x18062f99D35AB057ca85506dadBF6015e20E0555,        // populate with deployed spell if deployed
+            deployed_spell_created:         1619100860,                 // use get-created-timestamp.sh if deployed
+            previous_spell:                 address(0),        // supply if there is a need to test prior to its cast() function being called on-chain.
+            previous_spell_execution_time:  1614790361,                 // Time to warp to in order to allow the previous spell to be cast ignored if PREV_SPELL is SpellLike(address(0)).
+            office_hours_enabled:           false,              // true if officehours is expected to be enabled in the spell
+            expiration_threshold:           weekly_expiration  // (weekly_expiration,monthly_expiration) if weekly or monthly spell
+        });
+        spell = spellValues.deployed_spell != address(0) ?
+            DssSpell(spellValues.deployed_spell) : new DssSpell();
+
+        //
+        // Test for all system configuration changes
+        //
+        afterSpell = SystemValues({
+            pot_dsr:               0,                   // In basis points
+            pause_delay:           60,                  // In seconds
+            vow_wait:              3600,                // In seconds
+            vow_dump:              2,                   // In whole Dai units
+            vow_sump:              50,                  // In whole Dai units
+            vow_bump:              10,                  // In whole Dai units
+            vow_hump:              500,                 // In whole Dai units
+            flap_beg:              200,                 // In Basis Points
+            flap_ttl:              1 hours,             // In seconds
+            flap_tau:              1 hours,             // In seconds
+            cat_box:               10 * THOUSAND,       // In whole Dai units
+            dog_Hole:              10 * THOUSAND,       // In whole Dai units
+            pause_authority:       address(chief),      // Pause authority
+            osm_mom_authority:     address(chief),      // OsmMom authority
+            flipper_mom_authority: address(chief),      // FlipperMom authority
+            clipper_mom_authority: address(chief),      // ClipperMom authority
+            ilk_count:             27                   // Num expected in system
+        });
+
+        //
+        // Test for all collateral based changes here
+        //
+        afterSpell.collaterals["ETH-A"] = CollateralValues({
+            aL_enabled:   false,           // DssAutoLine is enabled?
+            aL_line:      0 * MILLION,     // In whole Dai units
+            aL_gap:       0 * MILLION,     // In whole Dai units
+            aL_ttl:       0,               // In seconds
+            line:         540 * MILLION,   // In whole Dai units
+            dust:         100,             // In whole Dai units
+            pct:          400,             // In basis points
+            mat:          15000,           // In basis points
+            liqType:      "flip",          // "" or "flip" or "clip"
+            liqOn:        true,            // If liquidations are enabled
+            chop:         1300,            // In basis points
+            cat_dunk:     500,             // In whole Dai units
+            flip_beg:     300,             // In basis points
+            flip_ttl:     1 hours,         // In seconds
+            flip_tau:     1 hours,         // In seconds
+            flipper_mom:  1,               // 1 if circuit breaker enabled
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["ETH-B"] = CollateralValues({
+            aL_enabled:   true,
+            aL_line:      50 * MILLION,
+            aL_gap:       5 * MILLION,
+            aL_ttl:       12 hours,
+            line:         0 * MILLION,     // Not being checked as there is auto line
+            dust:         100,
+            pct:          600,
+            mat:          13000,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["ETH-C"] = CollateralValues({
+            aL_enabled:   true,
+            aL_line:      2000 * MILLION,
+            aL_gap:       100 * MILLION,
+            aL_ttl:       12 hours,
+            line:         0 * MILLION,
+            dust:         100,
+            pct:          350,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["BAT-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          15000,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["USDC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         400 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          10100,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["USDC-B"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          5000,
+            mat:          12000,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["WBTC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         120 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          15000,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["TUSD-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         50 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          10100,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["KNC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["ZRX-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["MANA-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         1 * MILLION,
+            dust:         100,
+            pct:          1200,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["USDT-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          800,
+            mat:          15000,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["PAXUSD-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         30 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          10100,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["COMP-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         7 * MILLION,
+            dust:         100,
+            pct:          100,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["LRC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         3 * MILLION,
+            dust:         100,
+            pct:          300,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["LINK-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          200,
+            mat:          17500,
+            liqType:      "clip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     0,
+            flip_beg:     0,
+            flip_ttl:     0,
+            flip_tau:     0,
+            flipper_mom:  0,
+            dog_hole:     5 * THOUSAND,
+            clip_buf:     3000,
+            clip_tail:    140 minutes,
+            clip_cusp:    4000,
+            clip_chip:    10,
+            clip_tip:     0,
+            clipper_mom:  1,
+            calc_tau:     0,
+            calc_step:    90,
+            calc_cut:     9900
+        });
+        afterSpell.collaterals["BAL-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         4 * MILLION,
+            dust:         100,
+            pct:          500,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["YFI-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         7 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          17500,
+            liqType:      "clip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     0,
+            flip_beg:     0,
+            flip_ttl:     0,
+            flip_tau:     0,
+            flipper_mom:  0,
+            dog_hole:     5 * THOUSAND,
+            clip_buf:     3000,
+            clip_tail:    140 minutes,
+            clip_cusp:    4000,
+            clip_chip:    10,
+            clip_tip:     0,
+            clipper_mom:  1,
+            calc_tau:     0,
+            calc_step:    90,
+            calc_cut:     9900
+        });
+        afterSpell.collaterals["GUSD-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          10100,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["UNI-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         15 * MILLION,
+            dust:         100,
+            pct:          300,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["RENBTC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         2 * MILLION,
+            dust:         100,
+            pct:          600,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["AAVE-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         10 * MILLION,
+            dust:         100,
+            pct:          600,
+            mat:          17500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["UNIV2DAIETH-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         3 * MILLION,
+            dust:         100,
+            pct:          100,
+            mat:          12500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["PSM-USDC-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         500 * MILLION,
+            dust:         0,
+            pct:          0,
+            mat:          10000,
+            liqType:      "flip",
+            liqOn:        false,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["RWA001-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         1 * THOUSAND,
+            dust:         0,
+            pct:          300,
+            mat:          10000,
+            liqType:      "",
+            liqOn:        false,
+            chop:         0,
+            cat_dunk:     0,
+            flip_beg:     0,
+            flip_ttl:     0,
+            flip_tau:     0,
+            flipper_mom:  0,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["RWA002-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         0,
+            pct:          350,
+            mat:          10500,
+            liqType:      "",
+            liqOn:        false,
+            chop:         0,
+            cat_dunk:     0,
+            flip_beg:     0,
+            flip_ttl:     0,
+            flip_tau:     0,
+            flipper_mom:  0,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+        afterSpell.collaterals["PAXG-A"] = CollateralValues({
+            aL_enabled:   false,
+            aL_line:      0 * MILLION,
+            aL_gap:       0 * MILLION,
+            aL_ttl:       0,
+            line:         5 * MILLION,
+            dust:         100,
+            pct:          400,
+            mat:          12500,
+            liqType:      "flip",
+            liqOn:        true,
+            chop:         1300,
+            cat_dunk:     500,
+            flip_beg:     300,
+            flip_ttl:     1 hours,
+            flip_tau:     1 hours,
+            flipper_mom:  1,
+            dog_hole:     0,
+            clip_buf:     0,
+            clip_tail:    0,
+            clip_cusp:    0,
+            clip_chip:    0,
+            clip_tip:     0,
+            clipper_mom:  0,
+            calc_tau:     0,
+            calc_step:    0,
+            calc_cut:     0
+        });
+    }
+
+    function scheduleWaitAndCastFailDay() public {
+        spell.schedule();
+
+        uint256 castTime = block.timestamp + pause.delay();
+        uint256 day = (castTime / 1 days + 3) % 7;
+        if (day < 5) {
+            castTime += 5 days - day * 86400;
+        }
+
+        hevm.warp(castTime);
+        spell.cast();
+    }
+
+    function scheduleWaitAndCastFailEarly() public {
+        spell.schedule();
+
+        uint256 castTime = block.timestamp + pause.delay() + 24 hours;
+        uint256 hour = castTime / 1 hours % 24;
+        if (hour >= 14) {
+            castTime -= hour * 3600 - 13 hours;
+        }
+
+        hevm.warp(castTime);
+        spell.cast();
+    }
+
+    function scheduleWaitAndCastFailLate() public {
+        spell.schedule();
+
+        uint256 castTime = block.timestamp + pause.delay();
+        uint256 hour = castTime / 1 hours % 24;
+        if (hour < 21) {
+            castTime += 21 hours - hour * 3600;
+        }
+
+        hevm.warp(castTime);
+        spell.cast();
+    }
+
+    function vote(address spell_) private {
+        if (chief.hat() != spell_) {
+            hevm.store(
+                address(gov),
+                keccak256(abi.encode(address(this), uint256(1))),
+                bytes32(uint256(999999999999 ether))
+            );
+            gov.approve(address(chief), uint256(-1));
+            chief.lock(999999999999 ether);
+
+            address[] memory slate = new address[](1);
+
+            assertTrue(!DssSpell(spell_).done());
+
+            slate[0] = spell_;
+
+            chief.vote(slate);
+            chief.lift(spell_);
+        }
+        assertEq(chief.hat(), spell_);
+    }
+
+    function scheduleWaitAndCast(address spell_) public {
+        DssSpell(spell_).schedule();
+
+        hevm.warp(DssSpell(spell_).nextCastTime());
+
+        DssSpell(spell_).cast();
+    }
+
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    function checkSystemValues(SystemValues storage values) internal {
+        // dsr
+        uint expectedDSRRate = rates.rates(values.pot_dsr);
+        // make sure dsr is less than 100% APR
+        // bc -l <<< 'scale=27; e( l(2.00)/(60 * 60 * 24 * 365) )'
+        // 1000000021979553151239153027
+        assertTrue(
+            pot.dsr() >= RAY && pot.dsr() < 1000000021979553151239153027
+        );
+        assertTrue(diffCalc(expectedRate(values.pot_dsr), yearlyYield(expectedDSRRate)) <= TOLERANCE);
+
+        {
+        // Line values in RAD
+        assertTrue(
+            (vat.Line() >= RAD && vat.Line() < 100 * BILLION * RAD) ||
+            vat.Line() == 0
+        );
+        }
+
+        // Pause delay
+        assertEq(pause.delay(), values.pause_delay);
+
+        // wait
+        assertEq(vow.wait(), values.vow_wait);
+        {
+        // dump values in WAD
+        uint normalizedDump = values.vow_dump * WAD;
+        assertEq(vow.dump(), normalizedDump);
+        assertTrue(
+            (vow.dump() >= WAD && vow.dump() < 2 * THOUSAND * WAD) ||
+            vow.dump() == 0
+        );
+        }
+        {
+        // sump values in RAD
+        uint normalizedSump = values.vow_sump * RAD;
+        assertEq(vow.sump(), normalizedSump);
+        assertTrue(
+            (vow.sump() >= RAD && vow.sump() < 500 * THOUSAND * RAD) ||
+            vow.sump() == 0
+        );
+        }
+        {
+        // bump values in RAD
+        uint normalizedBump = values.vow_bump * RAD;
+        assertEq(vow.bump(), normalizedBump);
+        assertTrue(
+            (vow.bump() >= RAD && vow.bump() < HUNDRED * THOUSAND * RAD) ||
+            vow.bump() == 0
+        );
+        }
+        {
+        // hump values in RAD
+        uint normalizedHump = values.vow_hump * RAD;
+        assertEq(vow.hump(), normalizedHump);
+        assertTrue(
+            (vow.hump() >= RAD && vow.hump() < HUNDRED * MILLION * RAD) ||
+            vow.hump() == 0
+        );
+        }
+
+        // box value in RAD
+        {
+            uint normalizedBox = values.cat_box * RAD;
+            assertEq(cat.box(), normalizedBox);
+            assertTrue(cat.box() >= THOUSAND * RAD);
+            assertTrue(cat.box() < 50 * MILLION * RAD);
+        }
+
+        // Hole value in RAD
+        {
+            uint normalizedHole = values.dog_Hole * RAD;
+            assertEq(dog.Hole(), normalizedHole);
+            assertTrue(dog.Hole() >= THOUSAND * RAD);
+            assertTrue(dog.Hole() < 50 * MILLION * RAD);
+        }
+
+        // check Pause authority
+        assertEq(pause.authority(), values.pause_authority);
+
+        // check OsmMom authority
+        assertEq(osmMom.authority(), values.osm_mom_authority);
+
+        // check FlipperMom authority
+        assertEq(flipMom.authority(), values.flipper_mom_authority);
+
+        // check ClipperMom authority
+        assertEq(clipMom.authority(), values.clipper_mom_authority);
+
+        // check number of ilks
+        assertEq(reg.count(), values.ilk_count);
+
+        // flap
+        // check beg value
+        uint256 normalizedTestBeg = (values.flap_beg + 10000)  * 10**14;
+        assertEq(flap.beg(), normalizedTestBeg);
+        assertTrue(flap.beg() >= WAD && flap.beg() <= 110 * WAD / 100); // gte 0% and lte 10%
+        // Check flap ttl and sanity checks
+        assertEq(flap.ttl(), values.flap_ttl);
+        assertTrue(flap.ttl() > 0 && flap.ttl() < 86400); // gt 0 && lt 1 day
+        // Check flap tau and sanity checks
+        assertEq(flap.tau(), values.flap_tau);
+        assertTrue(flap.tau() > 0 && flap.tau() < 2678400); // gt 0 && lt 1 month
+        assertTrue(flap.tau() >= flap.ttl());
+    }
+
+    function checkCollateralValues(SystemValues storage values) internal {
+        uint256 sumlines;
+        bytes32[] memory ilks = reg.list();
+        for(uint256 i = 0; i < ilks.length; i++) {
+            bytes32 ilk = ilks[i];
+            (uint256 duty,)  = jug.ilks(ilk);
+
+            assertEq(duty, rates.rates(values.collaterals[ilk].pct));
+            // make sure duty is less than 1000% APR
+            // bc -l <<< 'scale=27; e( l(10.00)/(60 * 60 * 24 * 365) )'
+            // 1000000073014496989316680335
+            assertTrue(duty >= RAY && duty < 1000000073014496989316680335);  // gt 0 and lt 1000%
+            assertTrue(diffCalc(expectedRate(values.collaterals[ilk].pct), yearlyYield(rates.rates(values.collaterals[ilk].pct))) <= TOLERANCE);
+            assertTrue(values.collaterals[ilk].pct < THOUSAND * THOUSAND);   // check value lt 1000%
+            {
+            (,,, uint256 line, uint256 dust) = vat.ilks(ilk);
+            // Convert whole Dai units to expected RAD
+            uint256 normalizedTestLine = values.collaterals[ilk].line * RAD;
+            sumlines += line;
+            (uint256 aL_line, uint256 aL_gap, uint256 aL_ttl,,) = autoLine.ilks(ilk);
+            if (!values.collaterals[ilk].aL_enabled) {
+                assertTrue(aL_line == 0);
+                assertEq(line, normalizedTestLine);
+                assertTrue((line >= RAD && line < 10 * BILLION * RAD) || line == 0);  // eq 0 or gt eq 1 RAD and lt 10B
+            } else {
+                assertTrue(aL_line > 0);
+                assertEq(aL_line, values.collaterals[ilk].aL_line * RAD);
+                assertEq(aL_gap, values.collaterals[ilk].aL_gap * RAD);
+                assertEq(aL_ttl, values.collaterals[ilk].aL_ttl);
+                assertTrue((aL_line >= RAD && aL_line < 10 * BILLION * RAD) || aL_line == 0); // eq 0 or gt eq 1 RAD and lt 10B
+            }
+            uint256 normalizedTestDust = values.collaterals[ilk].dust * RAD;
+            assertEq(dust, normalizedTestDust);
+            assertTrue((dust >= RAD && dust < 10 * THOUSAND * RAD) || dust == 0); // eq 0 or gt eq 1 and lt 10k
+            }
+
+            {
+            (,uint256 mat) = spotter.ilks(ilk);
+            // Convert BP to system expected value
+            uint256 normalizedTestMat = (values.collaterals[ilk].mat * 10**23);
+            assertEq(mat, normalizedTestMat);
+            assertTrue(mat >= RAY && mat < 10 * RAY);    // cr eq 100% and lt 1000%
+            }
+
+            if (values.collaterals[ilk].liqType == "flip") {
+                {
+                assertEq(reg.class(ilk), 2);
+                (bool ok, bytes memory val) = reg.xlip(ilk).call(abi.encodeWithSignature("cat()"));
+                assertTrue(ok);
+                assertEq(abi.decode(val, (address)), address(cat));
+                }
+                {
+                (, uint256 chop, uint256 dunk) = cat.ilks(ilk);
+                // Convert BP to system expected value
+                uint256 normalizedTestChop = (values.collaterals[ilk].chop * 10**14) + WAD;
+                assertEq(chop, normalizedTestChop);
+                // make sure chop is less than 100%
+                assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
+
+                // Convert whole Dai units to expected RAD
+                uint256 normalizedTestDunk = values.collaterals[ilk].cat_dunk * RAD;
+                assertEq(dunk, normalizedTestDunk);
+                assertTrue(dunk >= RAD && dunk < MILLION * RAD);
+
+                (address flipper,,) = cat.ilks(ilk);
+                FlipAbstract flip = FlipAbstract(flipper);
+                // Convert BP to system expected value
+                uint256 normalizedTestBeg = (values.collaterals[ilk].flip_beg + 10000)  * 10**14;
+                assertEq(uint256(flip.beg()), normalizedTestBeg);
+                assertTrue(flip.beg() >= WAD && flip.beg() <= 110 * WAD / 100); // gte 0% and lte 10%
+                assertEq(uint256(flip.ttl()), values.collaterals[ilk].flip_ttl);
+                assertTrue(flip.ttl() >= 600 && flip.ttl() < 10 hours);         // gt eq 10 minutes and lt 10 hours
+                assertEq(uint256(flip.tau()), values.collaterals[ilk].flip_tau);
+                assertTrue(flip.tau() >= 600 && flip.tau() <= 3 days);          // gt eq 10 minutes and lt eq 3 days
+
+                assertEq(flip.wards(address(flipMom)), values.collaterals[ilk].flipper_mom);
+
+                assertEq(flip.wards(address(cat)), values.collaterals[ilk].liqOn ? 1 : 0);
+                assertEq(flip.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+                }
+            }
+            if (values.collaterals[ilk].liqType == "clip") {
+                {
+                assertEq(reg.class(ilk), 1);
+                (bool ok, bytes memory val) = reg.xlip(ilk).call(abi.encodeWithSignature("dog()"));
+                assertTrue(ok);
+                assertEq(abi.decode(val, (address)), address(dog));
+                }
+                {
+                (, uint256 chop, uint256 hole,) = dog.ilks(ilk);
+                // Convert BP to system expected value
+                uint256 normalizedTestChop = (values.collaterals[ilk].chop * 10**14) + WAD;
+                assertEq(chop, normalizedTestChop);
+                // make sure chop is less than 100%
+                assertTrue(chop >= WAD && chop < 2 * WAD);   // penalty gt eq 0% and lt 100%
+
+                // Convert whole Dai units to expected RAD
+                uint256 normalizedTesthole = values.collaterals[ilk].dog_hole * RAD;
+                assertEq(hole, normalizedTesthole);
+                assertTrue(hole >= RAD && hole < 20 * MILLION * RAD);
+                }
+                (address clipper,,,) = dog.ilks(ilk);
+                ClipAbstract clip = ClipAbstract(clipper);
+                {
+                // Convert BP to system expected value
+                uint256 normalizedTestBuf = (values.collaterals[ilk].clip_buf + 10000)  * 10**23;
+                assertEq(uint256(clip.buf()), normalizedTestBuf);
+                assertTrue(clip.buf() >= RAY && clip.buf() <= 2 * RAY); // gte 0% and lte 100%
+                assertEq(uint256(clip.tail()), values.collaterals[ilk].clip_tail);
+                assertTrue(clip.tail() >= 1200 && clip.tail() < 10 hours); // gt eq 20 minutes and lt 10 hours
+                uint256 normalizedTestCusp = (values.collaterals[ilk].clip_cusp)  * 10**23;
+                assertEq(uint256(clip.cusp()), normalizedTestCusp);
+                assertTrue(clip.cusp() >= RAY / 10 && clip.cusp() < RAY); // gte 10% and lt 100%
+                assertTrue(rmul(clip.buf(), clip.cusp()) <= RAY);
+                uint256 normalizedTestChip = (values.collaterals[ilk].clip_chip)  * 10**14;
+                assertEq(uint256(clip.chip()), normalizedTestChip);
+                assertTrue(clip.chip() < 1 * WAD / 100); // lt 13% (typical liquidation penalty)
+                uint256 normalizedTestTip = values.collaterals[ilk].clip_tip * RAD;
+                assertEq(uint256(clip.tip()), normalizedTestTip);
+                assertTrue(clip.tip() == 0 || clip.tip() >= RAD && clip.tip() <= 100 * RAD);
+
+                assertEq(clip.wards(address(clipMom)), values.collaterals[ilk].clipper_mom);
+
+                if (values.collaterals[ilk].liqOn) {
+                    assertEq(clip.stopped(), 0);
+                } else {
+                    assertTrue(clip.stopped() > 0);
+                }
+
+                assertEq(clip.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+                }
+                {
+                    (bool exists, bytes memory value) = clip.calc().call(abi.encodeWithSignature("tau()"));
+                    assertEq(exists ? abi.decode(value, (uint256)) : 0, values.collaterals[ilk].calc_tau);
+                    (exists, value) = clip.calc().call(abi.encodeWithSignature("step()"));
+                    assertEq(exists ? abi.decode(value, (uint256)) : 0, values.collaterals[ilk].calc_step);
+                    (exists, value) = clip.calc().call(abi.encodeWithSignature("cut()"));
+                    uint256 normalizedTestCut = values.collaterals[ilk].calc_cut * 10**23;
+                    assertEq(exists ? abi.decode(value, (uint256)) : 0, normalizedTestCut);
+                }
+            }
+            if (reg.class(ilk) < 3) {
+                {
+                GemJoinAbstract join = GemJoinAbstract(reg.join(ilk));
+                assertEq(join.wards(address(pauseProxy)), 1); // Check pause_proxy ward
+                }
+            }
+        }
+        //       actual    expected
+        assertEq(sumlines, vat.Line());
+    }
+
+    function getOSMPrice(address pip) internal returns (uint256) {
+        // hevm.load is to pull the price from the LP Oracle storage bypassing the whitelist
+        uint256 price = uint256(hevm.load(
+            pip,
+            bytes32(uint256(3))
+        )) & uint128(-1);   // Price is in the second half of the 32-byte storage slot
+
+        // Price is bounded in the spot by around 10^23
+        // Give a 10^9 buffer for price appreciation over time
+        // Note: This currently can't be hit due to the uint112, but we want to backstop
+        //       once the PIP uint size is increased
+        assertTrue(price <= (10 ** 14) * WAD);
+
+        return price;
+    }
+
+    function getUNIV2LPPrice(address pip) internal returns (uint256) {
+        // hevm.load is to pull the price from the LP Oracle storage bypassing the whitelist
+        uint256 price = uint256(hevm.load(
+            pip,
+            bytes32(uint256(6))
+        )) & uint128(-1);   // Price is in the second half of the 32-byte storage slot
+
+        // Price is bounded in the spot by around 10^23
+        // Give a 10^9 buffer for price appreciation over time
+        // Note: This currently can't be hit due to the uint112, but we want to backstop
+        //       once the PIP uint size is increased
+        assertTrue(price <= (10 ** 14) * WAD);
+
+        return price;
+    }
+
+    function giveTokens(DSTokenAbstract token, uint256 amount) internal {
+        // Edge case - balance is already set for some reason
+        if (token.balanceOf(address(this)) == amount) return;
+
+        for (int i = 0; i < 100; i++) {
+            // Scan the storage for the balance storage slot
+            bytes32 prevValue = hevm.load(
+                address(token),
+                keccak256(abi.encode(address(this), uint256(i)))
+            );
+            hevm.store(
+                address(token),
+                keccak256(abi.encode(address(this), uint256(i))),
+                bytes32(amount)
+            );
+            if (token.balanceOf(address(this)) == amount) {
+                // Found it
+                return;
+            } else {
+                // Keep going after restoring the original value
+                hevm.store(
+                    address(token),
+                    keccak256(abi.encode(address(this), uint256(i))),
+                    prevValue
+                );
+            }
+        }
+
+        // We have failed if we reach here
+        assertTrue(false);
+    }
+
+	function checkIlkIntegration(
+        bytes32 _ilk,
+        GemJoinAbstract join,
+        FlipAbstract flip,
+        address pip,
+        bool _isOSM,
+        bool _checkLiquidations,
+        bool _transferFee
+    ) public {
+        DSTokenAbstract token = DSTokenAbstract(join.gem());
+
+        if (_isOSM) OsmAbstract(pip).poke();
+        hevm.warp(block.timestamp + 3601);
+        if (_isOSM) OsmAbstract(pip).poke();
+        spotter.poke(_ilk);
+
+        // Authorization
+        assertEq(join.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(join)), 1);
+        assertEq(flip.wards(address(end)), 1);
+        assertEq(flip.wards(address(flipMom)), 1);
+        if (_isOSM) {
+            assertEq(OsmAbstract(pip).wards(address(osmMom)), 1);
+            assertEq(OsmAbstract(pip).bud(address(spotter)), 1);
+            assertEq(OsmAbstract(pip).bud(address(end)), 1);
+            assertEq(MedianAbstract(OsmAbstract(pip).src()).bud(pip), 1);
+        }
+
+        (,,,, uint256 dust) = vat.ilks(_ilk);
+        dust /= RAY;
+        uint256 amount = 2 * dust * WAD / (_isOSM ? getOSMPrice(pip) : uint256(DSValueAbstract(pip).read()));
+        giveTokens(token, amount);
+
+        assertEq(token.balanceOf(address(this)), amount);
+        assertEq(vat.gem(_ilk, address(this)), 0);
+        token.approve(address(join), amount);
+        join.join(address(this), amount);
+        assertEq(token.balanceOf(address(this)), 0);
+        if (_transferFee) {
+            amount = vat.gem(_ilk, address(this));
+            assertTrue(amount > 0);
+        }
+        assertEq(vat.gem(_ilk, address(this)), amount);
+
+        // Tick the fees forward so that art != dai in wad units
+        hevm.warp(block.timestamp + 1);
+        jug.drip(_ilk);
+
+        // Deposit collateral, generate DAI
+        (,uint256 rate,,,) = vat.ilks(_ilk);
+        assertEq(vat.dai(address(this)), 0);
+        vat.frob(_ilk, address(this), address(this), address(this), int256(amount), int256(divup(mul(RAY, dust), rate)));
+        assertEq(vat.gem(_ilk, address(this)), 0);
+        assertTrue(vat.dai(address(this)) >= dust * RAY);
+        assertTrue(vat.dai(address(this)) <= (dust + 1) * RAY);
+
+        // Payback DAI, withdraw collateral
+        vat.frob(_ilk, address(this), address(this), address(this), -int256(amount), -int256(divup(mul(RAY, dust), rate)));
+        assertEq(vat.gem(_ilk, address(this)), amount);
+        assertEq(vat.dai(address(this)), 0);
+
+        // Withdraw from adapter
+        join.exit(address(this), amount);
+        if (_transferFee) {
+            amount = token.balanceOf(address(this));
+        }
+        assertEq(token.balanceOf(address(this)), amount);
+        assertEq(vat.gem(_ilk, address(this)), 0);
+
+        // Generate new DAI to force a liquidation
+        token.approve(address(join), amount);
+        join.join(address(this), amount);
+        if (_transferFee) {
+            amount = vat.gem(_ilk, address(this));
+        }
+        // dart max amount of DAI
+        (,,uint256 spotV,,) = vat.ilks(_ilk);
+        vat.frob(_ilk, address(this), address(this), address(this), int256(amount), int256(mul(amount, spotV) / rate));
+        hevm.warp(block.timestamp + 1);
+        jug.drip(_ilk);
+        assertEq(flip.kicks(), 0);
+        if (_checkLiquidations) {
+            cat.bite(_ilk, address(this));
+            assertEq(flip.kicks(), 1);
+        }
+
+        // Dump all dai for next run
+        vat.move(address(this), address(0x0), vat.dai(address(this)));
+    }
+
+	function checkUNIV2LPIntegration(
+        bytes32 _ilk,
+        GemJoinAbstract join,
+        FlipAbstract flip,
+        LPOsmAbstract pip,
+        address _medianizer1,
+        address _medianizer2,
+        bool _isMedian1,
+        bool _isMedian2,
+        bool _checkLiquidations
+    ) public {
+        DSTokenAbstract token = DSTokenAbstract(join.gem());
+
+        pip.poke();
+        hevm.warp(block.timestamp + 3601);
+        pip.poke();
+        spotter.poke(_ilk);
+
+        // Check medianizer sources
+        assertEq(pip.src(), address(token));
+        assertEq(pip.orb0(), _medianizer1);
+        assertEq(pip.orb1(), _medianizer2);
+
+        // Authorization
+        assertEq(join.wards(pauseProxy), 1);
+        assertEq(vat.wards(address(join)), 1);
+        assertEq(flip.wards(address(end)), 1);
+        assertEq(flip.wards(address(flipMom)), 1);
+        assertEq(pip.wards(address(osmMom)), 1);
+        assertEq(pip.bud(address(spotter)), 1);
+        assertEq(pip.bud(address(end)), 1);
+        if (_isMedian1) assertEq(MedianAbstract(_medianizer1).bud(address(pip)), 1);
+        if (_isMedian2) assertEq(MedianAbstract(_medianizer2).bud(address(pip)), 1);
+
+        (,,,, uint256 dust) = vat.ilks(_ilk);
+        dust /= RAY;
+        uint256 amount = 2 * dust * WAD / getUNIV2LPPrice(address(pip));
+        giveTokens(token, amount);
+
+        assertEq(token.balanceOf(address(this)), amount);
+        assertEq(vat.gem(_ilk, address(this)), 0);
+        token.approve(address(join), amount);
+        join.join(address(this), amount);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(vat.gem(_ilk, address(this)), amount);
+
+        // Tick the fees forward so that art != dai in wad units
+        hevm.warp(block.timestamp + 1);
+        jug.drip(_ilk);
+
+        // Deposit collateral, generate DAI
+        (,uint256 rate,,,) = vat.ilks(_ilk);
+        assertEq(vat.dai(address(this)), 0);
+        vat.frob(_ilk, address(this), address(this), address(this), int256(amount), int256(divup(mul(RAY, dust), rate)));
+        assertEq(vat.gem(_ilk, address(this)), 0);
+        assertTrue(vat.dai(address(this)) >= dust * RAY && vat.dai(address(this)) <= (dust + 1) * RAY);
+
+        // Payback DAI, withdraw collateral
+        vat.frob(_ilk, address(this), address(this), address(this), -int256(amount), -int256(divup(mul(RAY, dust), rate)));
+        assertEq(vat.gem(_ilk, address(this)), amount);
+        assertEq(vat.dai(address(this)), 0);
+
+        // Withdraw from adapter
+        join.exit(address(this), amount);
+        assertEq(token.balanceOf(address(this)), amount);
+        assertEq(vat.gem(_ilk, address(this)), 0);
+
+        // Generate new DAI to force a liquidation
+        token.approve(address(join), amount);
+        join.join(address(this), amount);
+        // dart max amount of DAI
+        (,,uint256 spotV,,) = vat.ilks(_ilk);
+        vat.frob(_ilk, address(this), address(this), address(this), int256(amount), int256(mul(amount, spotV) / rate));
+        hevm.warp(block.timestamp + 1);
+        jug.drip(_ilk);
+        assertEq(flip.kicks(), 0);
+        if (_checkLiquidations) {
+            cat.bite(_ilk, address(this));
+            assertEq(flip.kicks(), 1);
+        }
+
+        // Dump all dai for next run
+        vat.move(address(this), address(0x0), vat.dai(address(this)));
+    }
+
+    // function testCollateralIntegrations() public {
+    //     vote(address(spell));
+    //     scheduleWaitAndCast(address(spell));
+    //     assertTrue(spell.done());
+
+    //     // Insert new collateral tests here
+    //     checkIlkIntegration(
+    //         "PAXG-A",
+    //         GemJoinAbstract(addr.addr("MCD_JOIN_PAXG_A")),
+    //         FlipAbstract(addr.addr("MCD_FLIP_PAXG_A")),
+    //         addr.addr("PIP_PAXG"),
+    //         true,
+    //         true,
+    //         true
+    //     );
+    // }
+
+    function getExtcodesize(address target) public view returns (uint256 exsize) {
+        assembly {
+            exsize := extcodesize(target)
+        }
+    }
+
+    function testSpellIsCast_GENERAL() public {
+        string memory description = new DssSpell().description();
+        assertTrue(bytes(description).length > 0);
+        // DS-Test can't handle strings directly, so cast to a bytes32.
+        assertEq(stringToBytes32(spell.description()),
+                stringToBytes32(description));
+
+        if(address(spell) != address(spellValues.deployed_spell)) {
+            assertEq(spell.expiration(), (block.timestamp + spellValues.expiration_threshold));
+        } else {
+            assertEq(spell.expiration(), (spellValues.deployed_spell_created + spellValues.expiration_threshold));
+
+            // If the spell is deployed compare the on-chain bytecode size with the generated bytecode size.
+            //   extcodehash doesn't match, potentially because it's address-specific, avenue for further research.
+            address depl_spell = spellValues.deployed_spell;
+            address code_spell = address(new DssSpell());
+            assertEq(getExtcodesize(depl_spell), getExtcodesize(code_spell));
+        }
+
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        checkSystemValues(afterSpell);
+
+        checkCollateralValues(afterSpell);
+    }
+
+    function testNewChainlogValues() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        ChainlogAbstract chainLog = ChainlogAbstract(addr.addr("CHANGELOG"));
+
+        assertEq(chainLog.getAddress("MCD_CLIP_YFI_A"), addr.addr("MCD_CLIP_YFI_A"));
+        assertEq(chainLog.getAddress("MCD_CLIP_CALC_YFI_A"), addr.addr("MCD_CLIP_CALC_YFI_A"));
+        try chainLog.getAddress("MCD_FLIP_YFI_A") returns (address) {
+            assertTrue(false);
+        } catch {}
+
+        assertEq(chainLog.getAddress("LERP_FAB"), addr.addr("LERP_FAB"));
+    }
+
+    function testFailWrongDay() public {
+        require(spell.officeHours() == spellValues.office_hours_enabled);
+        if (spell.officeHours()) {
+            vote(address(spell));
+            scheduleWaitAndCastFailDay();
+        } else {
+            revert("Office Hours Disabled");
+        }
+    }
+
+    function testFailTooEarly() public {
+        require(spell.officeHours() == spellValues.office_hours_enabled);
+        if (spell.officeHours()) {
+            vote(address(spell));
+            scheduleWaitAndCastFailEarly();
+        } else {
+            revert("Office Hours Disabled");
+        }
+    }
+
+    function testFailTooLate() public {
+        require(spell.officeHours() == spellValues.office_hours_enabled);
+        if (spell.officeHours()) {
+            vote(address(spell));
+            scheduleWaitAndCastFailLate();
+        } else {
+            revert("Office Hours Disabled");
+        }
+    }
+
+    function testOnTime() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+    }
+
+    function testCastCost() public {
+        vote(address(spell));
+        spell.schedule();
+
+        castPreviousSpell();
+
+        hevm.warp(spell.nextCastTime());
+        uint256 startGas = gasleft();
+        spell.cast();
+        uint256 endGas = gasleft();
+        uint256 totalGas = startGas - endGas;
+
+        assertTrue(spell.done());
+        // Fail if cast is too expensive
+        assertTrue(totalGas <= 8 * MILLION);
+    }
+
+    function testSpellIsCast_YFI_A_CLIP() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        DSTokenAbstract YFI = DSTokenAbstract(addr.addr("YFI"));
+        GemJoinAbstract joinYFIA = GemJoinAbstract(addr.addr("MCD_JOIN_YFI_A"));
+        FlipAbstract flipYFIA = FlipAbstract(addr.addr("MCD_FLIP_YFI_A"));
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+        OsmAbstract pipYFI    = OsmAbstract(addr.addr("PIP_YFI"));
+
+        // Contracts set
+        assertEq(dog.vat(), address(vat));
+        assertEq(dog.vow(), address(vow));
+        (address clip,,,) = dog.ilks("YFI-A");
+        assertEq(clip, address(clipYFIA));
+        assertEq(clipYFIA.ilk(), "YFI-A");
+        assertEq(clipYFIA.vat(), address(vat));
+        assertEq(clipYFIA.vow(), address(vow));
+        assertEq(clipYFIA.dog(), address(dog));
+        assertEq(clipYFIA.spotter(), address(spotter));
+        assertEq(clipYFIA.calc(), addr.addr("MCD_CLIP_CALC_YFI_A"));
+
+        // Authorization
+        assertEq(flipYFIA.wards(address(cat))    , 0);
+        assertEq(flipYFIA.wards(address(flipMom)), 0);
+
+        assertEq(vat.wards(address(clipYFIA))    , 1);
+        assertEq(dog.wards(address(clipYFIA))    , 1);
+        assertEq(clipYFIA.wards(address(dog))    , 1);
+        assertEq(clipYFIA.wards(address(end))    , 1);
+        assertEq(clipYFIA.wards(address(clipMom)), 1);
+        assertEq(clipYFIA.wards(address(esm)), 1);
+
+        assertEq(pipYFI.bud(address(clipYFIA)), 1);
+        assertEq(pipYFI.bud(address(clipMom)), 1);
+
+        // Force max debt ceiling for YFI-A
+        hevm.store(
+            address(vat),
+            bytes32(uint256(keccak256(abi.encode(bytes32("YFI-A"), uint256(2)))) + 3),
+            bytes32(uint256(-1))
+        );
+
+        // Add balance to the test address
+        uint256 ilkAmt = 0.05 * 10 ** 18;
+
+        giveTokens(YFI, ilkAmt);
+        assertEq(YFI.balanceOf(address(this)), ilkAmt);
+
+        // Join to adapter
+        assertEq(vat.gem("YFI-A", address(this)), 0);
+        YFI.approve(address(joinYFIA), ilkAmt);
+        joinYFIA.join(address(this), ilkAmt);
+        assertEq(YFI.balanceOf(address(this)), 0);
+        assertEq(vat.gem("YFI-A", address(this)), ilkAmt);
+
+        // Generate new DAI to force a liquidation
+        (,uint256 rate, uint256 spot,,) = vat.ilks("YFI-A");
+        // dart max amount of DAI
+        int256 art = int256(mul(ilkAmt, spot) / rate);
+        vat.frob("YFI-A", address(this), address(this), address(this), int256(ilkAmt), art);
+        hevm.warp(block.timestamp + 1);
+        jug.drip("YFI-A");
+        assertEq(clipYFIA.kicks(), 0);
+        dog.bark("YFI-A", address(this), address(this));
+        assertEq(clipYFIA.kicks(), 1);
+
+        (,rate,,,) = vat.ilks("YFI-A");
+        uint256 debt = mul(mul(rate, uint256(art)), dog.chop("YFI-A")) / WAD;
+        hevm.store(
+            address(vat),
+            keccak256(abi.encode(address(this), uint256(5))),
+            bytes32(debt)
+        );
+        assertEq(vat.dai(address(this)), debt);
+        assertEq(vat.gem("YFI-A", address(this)), 0);
+
+        hevm.warp(block.timestamp + 20 minutes);
+        (, uint256 tab, uint256 lot, address usr,, uint256 top) = clipYFIA.sales(1);
+
+        assertEq(usr, address(this));
+        assertEq(tab, debt);
+        assertEq(lot, ilkAmt);
+        assertTrue(mul(lot, top) > tab); // There is enough collateral to cover the debt at current price
+
+        vat.hope(address(clipYFIA));
+        clipYFIA.take(1, lot, top, address(this), bytes(""));
+
+        (, tab, lot, usr,,) = clipYFIA.sales(1);
+        assertEq(usr, address(0));
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(vat.dai(address(this)), 0);
+        assertEq(vat.gem("YFI-A", address(this)), ilkAmt); // What was purchased + returned back as it is the owner of the vault
+    }
+
+    function testClipperMomSetBreaker() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // clipperMom is an authority-based contract, so here we set the Chieftain's hat
+        //  to the current contract to simulate governance authority.
+        hevm.store(
+            address(chief),
+            bytes32(uint256(12)),
+            bytes32(uint256(address(this)))
+        );
+
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+        assertEq(clipYFIA.stopped(), 0);
+        clipMom.setBreaker(address(clipYFIA), 1, 0);
+        assertEq(clipYFIA.stopped(), 1);
+        clipMom.setBreaker(address(clipYFIA), 2, 0);
+        assertEq(clipYFIA.stopped(), 2);
+        clipMom.setBreaker(address(clipYFIA), 3, 0);
+        assertEq(clipYFIA.stopped(), 3);
+        clipMom.setBreaker(address(clipYFIA), 0, 0);
+        assertEq(clipYFIA.stopped(), 0);
+    }
+
+    function testFailClipperMomTripBreaker() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // Assuming we're within bounds at time of testing, this shouldn't work.
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+        clipMom.tripBreaker(address(clipYFIA));
+    }
+
+    function testClipperMomTripBreaker() public {
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        // Hacking nxt price to 0x123 (and making it valid)
+        bytes32 hackedValue = 0x0000000000000000000000000000000100000000000000000000000000000123;
+
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+
+        hevm.store(address(addr.addr("PIP_YFI")), bytes32(uint256(4)), hackedValue);
+
+        assertEq(clipMom.tolerance(address(clipYFIA)), (RAY / 2)); // (RAY / 2) for 50%
+
+        // Price is hacked, anyone can trip the breaker
+        clipMom.tripBreaker(address(clipYFIA));
+
+        assertEq(clipYFIA.stopped(), 2);
+    }
+
+    function testLerp() public {
+        LerpFabLike factory = LerpFabLike(addr.addr("LERP_FAB"));
+
+        assertEq(vow.hump(), 500 * RAD);
+        assertEq(factory.count(), 0);
+
+        vote(address(spell));
+        scheduleWaitAndCast(address(spell));
+        assertTrue(spell.done());
+
+        assertEq(factory.count(), 1);
+        LerpLike lerp = LerpLike(factory.lerps("20210421_VOW_HUMP1"));
+
+        assertEq(vow.hump(), 500 * RAD);
+
+        // Should do nothing as we are before the start date
+        lerp.tick();
+        assertEq(vow.hump(), 500 * RAD);
+
+        // Warp to the start time Thu Apr 22 2021 16:00:00 GMT+0000
+        hevm.warp(1619107200);
+
+        // Should do nothing as we are exactly at the start date
+        lerp.tick();
+        assertEq(vow.hump(), 500 * RAD);
+
+        hevm.warp(now + 1 days);
+
+        // Should advance to an intermediary value
+        factory.tall();
+        assertTrue(vow.hump() > 500 * RAD);
+        assertTrue(vow.hump() < 1000 * RAD);
+
+        hevm.warp(now + 20 days);
+
+        // Should be done
+        factory.tall();
+        assertEq(factory.count(), 0);
+        assertEq(vow.hump(), 1000 * RAD);
+    }
+}

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -24,8 +24,9 @@ import "dss-interfaces/dss/ClipperMomAbstract.sol";
 import "dss-interfaces/dss/VowAbstract.sol";
 
 interface LerpFabLike {
-    function newLerp(address, bytes32, uint256, uint256, uint256, uint256) external returns (address);
+    function newLerp(bytes32, address, bytes32, uint256, uint256, uint256, uint256) external returns (address);
     function active(uint256) external returns (address);
+    function lerps(bytes32) external returns (address);
     function tall() external;
     function count() external returns (uint256);
 }
@@ -46,7 +47,7 @@ contract DssSpellAction is DssAction {
     address constant MCD_CLIP_YFI_A      = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2; 
     address constant MCD_CLIP_CALC_YFI_A = 0x54A18C6ceEBDf42D8532EBf5e0a67C430a51b2f6;
 
-    address constant LERP_FAB = 0x04b20CEf1d5d09B2E9084a1ee01c2dc2B25ea6eD;
+    address constant LERP_FAB = 0xa6766Ed3574bAFc6114618E74035C7bb5e9a6aa9;
 
     function actions() public override {
         address MCD_VAT = DssExecLib.vat();
@@ -116,7 +117,7 @@ contract DssSpellAction is DssAction {
         ClipAbstract(MCD_CLIP_YFI_A).upchost();
 
         // Increase the Surplus Buffer to 1000 DAI over 7 days starting Thu Apr 22 2021 16:00:00 GMT+0000
-        address lerp = LerpFabLike(LERP_FAB).newLerp(MCD_VOW, "hump", 1619107200, 500 * RAD, 1000 * RAD, 7 days);
+        address lerp = LerpFabLike(LERP_FAB).newLerp("20210421_VOW_HUMP1", MCD_VOW, "hump", 1619107200, 500 * RAD, 1000 * RAD, 7 days);
         VowAbstract(MCD_VOW).rely(lerp);
 
         // Replace flip to clip in the ilk registry

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -36,7 +36,7 @@ contract DssSpellAction is DssAction {
     uint256 constant RAD = 10**45;
 
     address constant MCD_CLIP_YFI_A      = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2; 
-    address constant MCD_CLIP_CALC_YFI_A = 0xbd586d6352Fcf0C45f77FC9348F4Ee7539F6e2bD;
+    address constant MCD_CLIP_CALC_YFI_A = 0x54A18C6ceEBDf42D8532EBf5e0a67C430a51b2f6;
 
     function actions() public override {
         address MCD_VAT = DssExecLib.vat();
@@ -116,7 +116,6 @@ contract DssSpellAction is DssAction {
 
         DssExecLib.setChangelogVersion("1.4.0");
     }
-
 }
 
 contract DssSpell is DssExec {

--- a/src/Kovan-DssSpell.sol
+++ b/src/Kovan-DssSpell.sol
@@ -21,6 +21,14 @@ import "dss-exec-lib/DssExec.sol";
 import "dss-exec-lib/DssAction.sol";
 import "dss-interfaces/dss/ClipAbstract.sol";
 import "dss-interfaces/dss/ClipperMomAbstract.sol";
+import "dss-interfaces/dss/VowAbstract.sol";
+
+interface LerpFabLike {
+    function newLerp(address, bytes32, uint256, uint256, uint256, uint256) external returns (address);
+    function active(uint256) external returns (address);
+    function tall() external;
+    function count() external returns (uint256);
+}
 
 contract DssSpellAction is DssAction {
 
@@ -37,6 +45,8 @@ contract DssSpellAction is DssAction {
 
     address constant MCD_CLIP_YFI_A      = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2; 
     address constant MCD_CLIP_CALC_YFI_A = 0x54A18C6ceEBDf42D8532EBf5e0a67C430a51b2f6;
+
+    address constant LERP_FAB = 0x04b20CEf1d5d09B2E9084a1ee01c2dc2B25ea6eD;
 
     function actions() public override {
         address MCD_VAT = DssExecLib.vat();
@@ -105,6 +115,10 @@ contract DssSpellAction is DssAction {
 
         ClipAbstract(MCD_CLIP_YFI_A).upchost();
 
+        // Increase the Surplus Buffer to 1000 DAI over 7 days starting Thu Apr 22 2021 16:00:00 GMT+0000
+        address lerp = LerpFabLike(LERP_FAB).newLerp(MCD_VOW, "hump", 1619107200, 500 * RAD, 1000 * RAD, 7 days);
+        VowAbstract(MCD_VOW).rely(lerp);
+
         // Replace flip to clip in the ilk registry
         DssExecLib.setContract(ILK_REGISTRY, "YFI-A", "xlip", MCD_CLIP_YFI_A);
         Fileable(ILK_REGISTRY).file("YFI-A", "class", 1);
@@ -113,6 +127,8 @@ contract DssSpellAction is DssAction {
         DssExecLib.setChangelogAddress("MCD_CLIP_YFI_A", MCD_CLIP_YFI_A);
         DssExecLib.setChangelogAddress("MCD_CLIP_CALC_YFI_A", MCD_CLIP_CALC_YFI_A);
         ChainlogLike(log).removeAddress("MCD_FLIP_YFI_A");
+
+        DssExecLib.setChangelogAddress("LERP_FAB", LERP_FAB);
 
         DssExecLib.setChangelogVersion("1.4.0");
     }

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -1757,6 +1757,7 @@ contract DssSpellTest is DSTest, DSMath {
         assertEq(clipYFIA.wards(address(dog))    , 1);
         assertEq(clipYFIA.wards(address(end))    , 1);
         assertEq(clipYFIA.wards(address(clipMom)), 1);
+        assertEq(clipYFIA.wards(address(esm)), 1);
 
         assertEq(pipYFI.bud(address(clipYFIA)), 1);
         assertEq(pipYFI.bud(address(clipMom)), 1);

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -1886,7 +1886,7 @@ contract DssSpellTest is DSTest, DSMath {
         assertTrue(spell.done());
 
         assertEq(factory.count(), 1);
-        LerpLike lerp = LerpLike(factory.active(0));
+        LerpLike lerp = LerpLike(factory.lerps("20210421_VOW_HUMP1"));
 
         assertEq(vow.hump(), 500 * RAD);
 

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -240,8 +240,8 @@ contract DssSpellTest is DSTest, DSMath {
         // Test for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:                 address(0),        // populate with deployed spell if deployed
-            deployed_spell_created:         1618926672,                 // use get-created-timestamp.sh if deployed
+            deployed_spell:                 0x18062f99D35AB057ca85506dadBF6015e20E0555,        // populate with deployed spell if deployed
+            deployed_spell_created:         1619100860,                 // use get-created-timestamp.sh if deployed
             previous_spell:                 address(0),        // supply if there is a need to test prior to its cast() function being called on-chain.
             previous_spell_execution_time:  1614790361,                 // Time to warp to in order to allow the previous spell to be cast ignored if PREV_SPELL is SpellLike(address(0)).
             office_hours_enabled:           false,              // true if officehours is expected to be enabled in the spell

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -1759,6 +1759,7 @@ contract DssSpellTest is DSTest, DSMath {
         assertEq(clipYFIA.wards(address(clipMom)), 1);
 
         assertEq(pipYFI.bud(address(clipYFIA)), 1);
+        assertEq(pipYFI.bud(address(clipMom)), 1);
 
         // Force max debt ceiling for YFI-A
         hevm.store(

--- a/src/Kovan-DssSpell.t.sol
+++ b/src/Kovan-DssSpell.t.sol
@@ -236,7 +236,7 @@ contract DssSpellTest is DSTest, DSMath {
         // Test for spell-specific parameters
         //
         spellValues = SpellValues({
-            deployed_spell:                 0x865D4A290DF651c17893eBb9B0ecFb61C242ba69,        // populate with deployed spell if deployed
+            deployed_spell:                 address(0),        // populate with deployed spell if deployed
             deployed_spell_created:         1618926672,                 // use get-created-timestamp.sh if deployed
             previous_spell:                 address(0),        // supply if there is a need to test prior to its cast() function being called on-chain.
             previous_spell_execution_time:  1614790361,                 // Time to warp to in order to allow the previous spell to be cast ignored if PREV_SPELL is SpellLike(address(0)).
@@ -757,24 +757,24 @@ contract DssSpellTest is DSTest, DSMath {
             dust:         100,
             pct:          400,
             mat:          17500,
-            liqType:      "flip",
+            liqType:      "clip",
             liqOn:        true,
             chop:         1300,
-            cat_dunk:     500,
-            flip_beg:     300,
-            flip_ttl:     1 hours,
-            flip_tau:     1 hours,
-            flipper_mom:  1,
-            dog_hole:     0,
-            clip_buf:     0,
-            clip_tail:    0,
-            clip_cusp:    0,
-            clip_chip:    0,
+            cat_dunk:     0,
+            flip_beg:     0,
+            flip_ttl:     0,
+            flip_tau:     0,
+            flipper_mom:  0,
+            dog_hole:     5 * THOUSAND,
+            clip_buf:     3000,
+            clip_tail:    140 minutes,
+            clip_cusp:    4000,
+            clip_chip:    10,
             clip_tip:     0,
-            clipper_mom:  0,
+            clipper_mom:  1,
             calc_tau:     0,
-            calc_step:    0,
-            calc_cut:     0
+            calc_step:    90,
+            calc_cut:     9900
         });
         afterSpell.collaterals["GUSD-A"] = CollateralValues({
             aL_enabled:   false,
@@ -1660,34 +1660,9 @@ contract DssSpellTest is DSTest, DSMath {
 
         ChainlogAbstract chainLog = ChainlogAbstract(addr.addr("CHANGELOG"));
 
-        try chainLog.getAddress("NS2DRP") returns (address) {
-            assertTrue(false);
-        } catch {}
-        try chainLog.getAddress("MCD_JOIN_NS2DRP_A") returns (address) {
-            assertTrue(false);
-        } catch {}
-        try chainLog.getAddress("NS2DRP_A_URN") returns (address) {
-            assertTrue(false);
-        } catch {}
-        try chainLog.getAddress("NS2DRP_A_INPUT_CONDUIT") returns (address) {
-            assertTrue(false);
-        } catch {}
-        try chainLog.getAddress("NS2DRP_A_OUTPUT_CONDUIT") returns (address) {
-            assertTrue(false);
-        } catch {}
-
-        assertEq(chainLog.getAddress("RWA002"), addr.addr("RWA002"));
-        assertEq(chainLog.getAddress("MCD_JOIN_RWA002_A"), addr.addr("MCD_JOIN_RWA002_A"));
-        assertEq(chainLog.getAddress("RWA002_A_URN"), addr.addr("RWA002_A_URN"));
-        assertEq(chainLog.getAddress("RWA002_A_INPUT_CONDUIT"), addr.addr("RWA002_A_INPUT_CONDUIT"));
-        assertEq(chainLog.getAddress("RWA002_A_OUTPUT_CONDUIT"), addr.addr("RWA002_A_OUTPUT_CONDUIT"));
-
-
-        assertEq(chainLog.getAddress("MCD_ESM"), addr.addr("MCD_ESM"));
-        try chainLog.getAddress("MCD_ESM_BUG") returns (address) {
-            assertTrue(false);
-        } catch {}
-        try chainLog.getAddress("MCD_ESM_ATTACK") returns (address) {
+        assertEq(chainLog.getAddress("MCD_CLIP_YFI_A"), addr.addr("MCD_CLIP_YFI_A"));
+        assertEq(chainLog.getAddress("MCD_CLIP_CALC_YFI_A"), addr.addr("MCD_CLIP_CALC_YFI_A"));
+        try chainLog.getAddress("MCD_FLIP_YFI_A") returns (address) {
             assertTrue(false);
         } catch {}
     }
@@ -1744,231 +1719,116 @@ contract DssSpellTest is DSTest, DSMath {
         assertTrue(totalGas <= 8 * MILLION);
     }
 
-    function testSpellIsCast_new_End_authorities() public {
-        assertEq(vat.wards(address(end_old)), 1);
-        assertEq(cat.wards(address(end_old)), 1);
-        assertEq(vow.wards(address(end_old)), 1);
-        assertEq(pot.wards(address(end_old)), 1);
-        assertEq(spotter.wards(address(end_old)), 1);
-
+    function testSpellIsCast_YFI_A_CLIP() public {
         vote(address(spell));
         scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
+
+        DSTokenAbstract YFI = DSTokenAbstract(addr.addr("YFI"));
+        GemJoinAbstract joinYFIA = GemJoinAbstract(addr.addr("MCD_JOIN_YFI_A"));
+        FlipAbstract flipYFIA = FlipAbstract(addr.addr("MCD_FLIP_YFI_A"));
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+        OsmAbstract pipYFI    = OsmAbstract(addr.addr("PIP_YFI"));
 
         // Contracts set
-        assertEq(end.vat(), address(vat));
-        assertEq(end.cat(), address(cat));
-        assertEq(end.dog(), address(dog));
-        assertEq(end.vow(), address(vow));
-        assertEq(end.pot(), address(pot));
-        assertEq(end.spot(), address(spotter));
+        assertEq(dog.vat(), address(vat));
+        assertEq(dog.vow(), address(vow));
+        (address clip,,,) = dog.ilks("YFI-A");
+        assertEq(clip, address(clipYFIA));
+        assertEq(clipYFIA.ilk(), "YFI-A");
+        assertEq(clipYFIA.vat(), address(vat));
+        assertEq(clipYFIA.vow(), address(vow));
+        assertEq(clipYFIA.dog(), address(dog));
+        assertEq(clipYFIA.spotter(), address(spotter));
+        assertEq(clipYFIA.calc(), addr.addr("MCD_CLIP_CALC_YFI_A"));
 
-        // Check end.wait
-        assertEq(end.wait(), end_old.wait());
+        // Authorization
+        assertEq(flipYFIA.wards(address(cat))    , 0);
+        assertEq(flipYFIA.wards(address(flipMom)), 0);
 
-        assertEq(esm.end(), address(end));
+        assertEq(vat.wards(address(clipYFIA))    , 1);
+        assertEq(dog.wards(address(clipYFIA))    , 1);
+        assertEq(clipYFIA.wards(address(dog))    , 1);
+        assertEq(clipYFIA.wards(address(end))    , 1);
+        assertEq(clipYFIA.wards(address(clipMom)), 1);
 
-        // Check flippers/clippers authorities and osms whitelisting
-        bytes32[] memory ilks = reg.list();
-        for (uint256 i = 0; i < ilks.length; i++) {
-            if (reg.class(ilks[i]) < 3) {
-                FlipAbstract xlip = FlipAbstract(reg.xlip(ilks[i]));
-                assertEq(xlip.wards(address(end)), 1);
-                assertEq(xlip.wards(address(end_old)), 0);
+        assertEq(pipYFI.bud(address(clipYFIA)), 1);
 
-                assertEq(xlip.wards(address(esm)), 1);
+        // Add balance to the test address
+        uint256 ilkAmt = 500 * WAD;
 
-                OsmAbstract osm = OsmAbstract(reg.pip(ilks[i]));
-                try osm.bud(address(123)) { // Check is an OSM or Median
-                    assertEq(osm.bud(address(end)), 1);
-                    assertEq(osm.bud(address(end_old)), 0);
-                } catch {}
-            }
-        }
+        giveTokens(YFI, ilkAmt);
+        assertEq(YFI.balanceOf(address(this)), ilkAmt);
 
-        // Check also old flipper for LINK-A
-        FlipAbstract oldFlipLINKA = FlipAbstract(addr.addr("MCD_FLIP_LINK_A"));
-        assertEq(oldFlipLINKA.wards(address(end)), 1);
-        assertEq(oldFlipLINKA.wards(address(end_old)), 0);
-        assertEq(oldFlipLINKA.wards(address(esm)), 1);
+        // Join to adapter
+        assertEq(vat.gem("YFI-A", address(this)), 0);
+        YFI.approve(address(joinYFIA), ilkAmt);
+        joinYFIA.join(address(this), ilkAmt);
+        assertEq(YFI.balanceOf(address(this)), 0);
+        assertEq(vat.gem("YFI-A", address(this)), ilkAmt);
 
-        assertEq(vat.wards(address(end_old)), 0);
-        assertEq(cat.wards(address(end_old)), 0);
-        assertEq(vow.wards(address(end_old)), 0);
-        assertEq(pot.wards(address(end_old)), 0);
-        assertEq(spotter.wards(address(end_old)), 0);
-
-        assertEq(vat.wards(address(end)), 1);
-        assertEq(cat.wards(address(end)), 1);
-        assertEq(dog.wards(address(end)), 1);
-        assertEq(vow.wards(address(end)), 1);
-        assertEq(pot.wards(address(end)), 1);
-        assertEq(spotter.wards(address(end)), 1);
-
-        assertEq(end.wards(address(esm)), 1);
-        assertEq(vat.wards(address(esm)), 1);
-        assertEq(end_old.wards(address(esm_old)), 1);
-    }
-
-    function testSpellIsCast_new_End_functionality() public {
-        vote(address(spell));
-        scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done());
-
-        DSTokenAbstract ETH = DSTokenAbstract(addr.addr("ETH"));
-        GemJoinAbstract joinETHA = GemJoinAbstract(addr.addr("MCD_JOIN_ETH_A"));
-        FlipAbstract flipETHA = FlipAbstract(addr.addr("MCD_FLIP_ETH_A"));
-
-        DSTokenAbstract BAT = DSTokenAbstract(addr.addr("BAT"));
-        GemJoinAbstract joinBATA = GemJoinAbstract(addr.addr("MCD_JOIN_BAT_A"));
-        FlipAbstract flipBATA = FlipAbstract(addr.addr("MCD_FLIP_BAT_A"));
-
-        DSTokenAbstract LINK = DSTokenAbstract(addr.addr("LINK"));
-        GemJoinAbstract joinLINKA = GemJoinAbstract(addr.addr("MCD_JOIN_LINK_A"));
-        ClipAbstract clipLINKA = ClipAbstract(addr.addr("MCD_CLIP_LINK_A"));
-
-        uint256 ilkAmt = 1 * THOUSAND * WAD;
-
-        giveTokens(ETH, ilkAmt);
-        giveTokens(BAT, ilkAmt);
-        giveTokens(LINK, ilkAmt);
-
-        ETH.approve(address(joinETHA), ilkAmt);
-        joinETHA.join(address(this), ilkAmt);
-        BAT.approve(address(joinBATA), ilkAmt);
-        joinBATA.join(address(this), ilkAmt);
-        LINK.approve(address(joinLINKA), ilkAmt);
-        joinLINKA.join(address(this), ilkAmt);
-
-        (,uint256 rate, uint256 spot,,) = vat.ilks("ETH-A");
-        vat.frob("ETH-A", address(this), address(this), address(this), int256(ilkAmt), int256(mul(ilkAmt, spot) / rate));
-        (, rate, spot,,) = vat.ilks("BAT-A");
-        vat.frob("BAT-A", address(this), address(this), address(this), int256(ilkAmt), int256(mul(ilkAmt, spot) / rate));
-        (, rate, spot,,) = vat.ilks("LINK-A");
-        vat.frob("LINK-A", address(this), address(this), address(this), int256(ilkAmt), int256(mul(ilkAmt, spot) / rate));
-
+        // Generate new DAI to force a liquidation
+        (,uint256 rate, uint256 spot,,) = vat.ilks("YFI-A");
+        // dart max amount of DAI
+        int256 art = int256(mul(ilkAmt, spot) / rate);
+        vat.frob("YFI-A", address(this), address(this), address(this), int256(ilkAmt), art);
         hevm.warp(block.timestamp + 1);
-        jug.drip("ETH-A");
-        jug.drip("BAT-A");
-        jug.drip("LINK-A");
+        jug.drip("YFI-A");
+        assertEq(clipYFIA.kicks(), 0);
+        dog.bark("YFI-A", address(this), address(this));
+        assertEq(clipYFIA.kicks(), 1);
 
-        uint256 auctionIdETHA = flipETHA.kicks() + 1;
-        uint256 auctionIdBATA = flipBATA.kicks() + 1;
-        uint256 auctionIdLINKA = clipLINKA.kicks() + 1;
-
-        cat.bite("ETH-A", address(this));
-        cat.bite("BAT-A", address(this));
-        dog.bark("LINK-A", address(this), address(this));
-
-        assertEq(flipETHA.kicks(), auctionIdETHA);
-        assertEq(flipBATA.kicks(), auctionIdBATA);
-        assertEq(clipLINKA.kicks(), auctionIdLINKA);
-
+        (,rate,,,) = vat.ilks("YFI-A");
+        uint256 debt = mul(mul(rate, uint256(art)), dog.chop("YFI-A")) / WAD;
         hevm.store(
-            address(end),
-            keccak256(abi.encode(address(this), uint256(0))),
-            bytes32(uint256(1))
+            address(vat),
+            keccak256(abi.encode(address(this), uint256(5))),
+            bytes32(debt)
         );
-        assertEq(end.wards(address(this)), 1);
+        assertEq(vat.dai(address(this)), debt);
+        assertEq(vat.gem("YFI-A", address(this)), 0);
 
-        end.cage();
-        end.cage("ETH-A");
-        end.cage("BAT-A");
-        end.cage("LINK-A");
+        hevm.warp(block.timestamp + 20 minutes);
+        (, uint256 tab, uint256 lot, address usr,, uint256 top) = clipYFIA.sales(1);
 
-        (,, address usr,,,,,) = flipETHA.bids(auctionIdETHA);
-        assertTrue(usr != address(0));
-        (,, usr,,,,,) = flipBATA.bids(auctionIdBATA);
-        assertTrue(usr != address(0));
-        (,,, usr,,) = clipLINKA.sales(auctionIdLINKA);
-        assertTrue(usr != address(0));
+        assertEq(usr, address(this));
+        assertEq(tab, debt);
+        assertEq(lot, ilkAmt);
+        assertTrue(mul(lot, top) > tab); // There is enough collateral to cover the debt at current price
 
-        end.skip("ETH-A", auctionIdETHA);
-        end.skip("BAT-A", auctionIdBATA);
-        end.snip("LINK-A", auctionIdLINKA);
+        vat.hope(address(clipYFIA));
+        clipYFIA.take(1, lot, top, address(this), bytes(""));
 
-        (,, usr,,,,,) = flipETHA.bids(auctionIdETHA);
-        assertTrue(usr == address(0));
-        (,, usr,,,,,) = flipBATA.bids(auctionIdBATA);
-        assertTrue(usr == address(0));
-        (,,, usr,,) = clipLINKA.sales(auctionIdLINKA);
-        assertTrue(usr == address(0));
-
-        end.skim("ETH-A", address(this));
-        end.skim("BAT-A", address(this));
-        end.skim("LINK-A", address(this));
-
-        end.free("ETH-A");
-        end.free("BAT-A");
-        end.free("LINK-A");
-
-        hevm.warp(block.timestamp + end.wait());
-
-        vow.heal(min(vat.dai(address(vow)), sub(sub(vat.sin(address(vow)), vow.Sin()), vow.Ash())));
-
-        end.thaw();
-
-        end.flow("ETH-A");
-        end.flow("BAT-A");
-        end.flow("LINK-A");
-
-        vat.hope(address(end));
-
-        uint256 daiToRedeem = vat.dai(address(this)) / RAY;
-        assertTrue(daiToRedeem > 0);
-
-        end.pack(daiToRedeem);
-
-        end.cash("ETH-A", daiToRedeem);
-        end.cash("BAT-A", daiToRedeem);
-        end.cash("LINK-A", daiToRedeem);
+        (, tab, lot, usr,,) = clipYFIA.sales(1);
+        assertEq(usr, address(0));
+        assertEq(tab, 0);
+        assertEq(lot, 0);
+        assertEq(vat.dai(address(this)), 0);
+        assertEq(vat.gem("YFI-A", address(this)), ilkAmt); // What was purchased + returned back as it is the owner of the vault
     }
 
-    function testSpellIsCast_new_ESM_authorities() public {
+    function testClipperMomSetBreaker() public {
         vote(address(spell));
         scheduleWaitAndCast(address(spell));
         assertTrue(spell.done());
 
-        assertTrue(esm.revokesGovernanceAccess());
+        // clipperMom is an authority-based contract, so here we set the Chieftain's hat
+        //  to the current contract to simulate governance authority.
+        hevm.store(
+            address(chief),
+            bytes32(uint256(12)),
+            bytes32(uint256(address(this)))
+        );
 
-        assertEq(end.wards(address(esm)), 1);
-        assertEq(vat.wards(address(esm)), 1);
-        assertEq(vat.wards(address(esm_old)), 0);
-
-        bytes32[] memory ilks = reg.list();
-        for (uint256 i = 0; i < ilks.length; i++) {
-            if (reg.class(ilks[i]) < 3) {
-                FlipAbstract xlip = FlipAbstract(reg.xlip(ilks[i]));
-                assertEq(xlip.wards(address(esm)), 1);
-                assertEq(xlip.wards(address(esm_old)), 0);
-            }
-        }
-
-        FlipAbstract oldFlipLINKA = FlipAbstract(addr.addr("MCD_FLIP_LINK_A"));
-        assertEq(oldFlipLINKA.wards(address(esm)), 1);
-        assertEq(oldFlipLINKA.wards(address(esm_old)), 0);
-    }
-
-    function testSpellIsCast_new_ESM_functionality() public {
-        vote(address(spell));
-        scheduleWaitAndCast(address(spell));
-        assertTrue(spell.done());
-
-        uint256 amt = 75 * THOUSAND * WAD;
-        assertEq(esm.min(), amt);
-        giveTokens(gov, amt);
-        gov.approve(address(esm), amt);
-        esm.join(amt);
-
-        assertEq(vat.wards(address(pauseProxy)), 1);
-        esm.fire();
-        assertEq(vat.wards(address(pauseProxy)), 0);
-        assertEq(end.live(), 0);
-        assertEq(vat.live(), 0);
-
-        ClipAbstract clipLINKA = ClipAbstract(addr.addr("MCD_CLIP_LINK_A"));
-        assertEq(clipLINKA.wards(address(pauseProxy)), 1);
-        esm.deny(address(clipLINKA));
-        assertEq(clipLINKA.wards(address(pauseProxy)), 0);
+        ClipAbstract clipYFIA = ClipAbstract(addr.addr("MCD_CLIP_YFI_A"));
+        assertEq(clipYFIA.stopped(), 0);
+        clipMom.setBreaker(address(clipYFIA), 1, 0);
+        assertEq(clipYFIA.stopped(), 1);
+        clipMom.setBreaker(address(clipYFIA), 2, 0);
+        assertEq(clipYFIA.stopped(), 2);
+        clipMom.setBreaker(address(clipYFIA), 3, 0);
+        assertEq(clipYFIA.stopped(), 3);
+        clipMom.setBreaker(address(clipYFIA), 0, 0);
+        assertEq(clipYFIA.stopped(), 0);
     }
 }

--- a/src/test/addresses_kovan.sol
+++ b/src/test/addresses_kovan.sol
@@ -158,5 +158,6 @@ contract Addresses {
         addr["PIP_PAXG"]               = 0x31CceDBc45179f17CfD34967680C6560b6509C1A;
         addr["MCD_JOIN_PAXG_A"]        = 0x822248F31bd899DE327A760a78B6C84889aF180D;
         addr["MCD_FLIP_PAXG_A"]        = 0x0b2e32151041641Fa37a1F54D7eD526989eF9B73;
+        addr["LERP_FAB"]               = 0x04b20CEf1d5d09B2E9084a1ee01c2dc2B25ea6eD;
     }
 }

--- a/src/test/addresses_kovan.sol
+++ b/src/test/addresses_kovan.sol
@@ -116,6 +116,8 @@ contract Addresses {
         addr["PIP_YFI"]                = 0x9D8255dc4e25bB85e49c65B21D8e749F2293862a;
         addr["MCD_JOIN_YFI_A"]         = 0x5b683137481F2FE683E2f2385792B1DeB018050F;
         addr["MCD_FLIP_YFI_A"]         = 0x5eB5D3B028CD255d79019f7C44a502b31bFFde9d;
+        addr["MCD_CLIP_YFI_A"]         = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2;
+        addr["MCD_CLIP_CALC_YFI_A"]    = 0xbd586d6352Fcf0C45f77FC9348F4Ee7539F6e2bD;
         addr["GUSD"]                   = 0x31D8EdbF6F33ef858c80d68D06Ec83f33c2aA150;
         addr["PIP_GUSD"]               = 0xb6630DE6Eda0f3f3d96Db4639914565d6b82CfEF;
         addr["MCD_JOIN_GUSD_A"]        = 0x0c6B26e6AB583D2e4528034037F74842ea988909;

--- a/src/test/addresses_kovan.sol
+++ b/src/test/addresses_kovan.sol
@@ -158,6 +158,6 @@ contract Addresses {
         addr["PIP_PAXG"]               = 0x31CceDBc45179f17CfD34967680C6560b6509C1A;
         addr["MCD_JOIN_PAXG_A"]        = 0x822248F31bd899DE327A760a78B6C84889aF180D;
         addr["MCD_FLIP_PAXG_A"]        = 0x0b2e32151041641Fa37a1F54D7eD526989eF9B73;
-        addr["LERP_FAB"]               = 0x04b20CEf1d5d09B2E9084a1ee01c2dc2B25ea6eD;
+        addr["LERP_FAB"]               = 0xa6766Ed3574bAFc6114618E74035C7bb5e9a6aa9;
     }
 }

--- a/src/test/addresses_kovan.sol
+++ b/src/test/addresses_kovan.sol
@@ -117,7 +117,7 @@ contract Addresses {
         addr["MCD_JOIN_YFI_A"]         = 0x5b683137481F2FE683E2f2385792B1DeB018050F;
         addr["MCD_FLIP_YFI_A"]         = 0x5eB5D3B028CD255d79019f7C44a502b31bFFde9d;
         addr["MCD_CLIP_YFI_A"]         = 0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2;
-        addr["MCD_CLIP_CALC_YFI_A"]    = 0xbd586d6352Fcf0C45f77FC9348F4Ee7539F6e2bD;
+        addr["MCD_CLIP_CALC_YFI_A"]    = 0x54A18C6ceEBDf42D8532EBf5e0a67C430a51b2f6;
         addr["GUSD"]                   = 0x31D8EdbF6F33ef858c80d68D06Ec83f33c2aA150;
         addr["PIP_GUSD"]               = 0xb6630DE6Eda0f3f3d96Db4639914565d6b82CfEF;
         addr["MCD_JOIN_GUSD_A"]        = 0x0c6B26e6AB583D2e4528034037F74842ea988909;


### PR DESCRIPTION
# Description

Spell Description:

COB Team Name or Author(s):

# Contribution Checklist

- [ ] First commit title starts with COB Team Name and Collateral type (e.g. `___-TOKEN-X`)
- [ ] Code approved
- [ ] Tests approved
- [ ] CI Tests pass

# LIQ-2.0 Checklist

# `clipper` foreach `ilk`

- [ ] Validate constructor argument(s) are correct
- [ ] Ensure that the deployer was removed
- [ ] Ensure that the pause proxy was relied
- [ ] `dog.file(ilk, "clip", clipper)`
- [ ] `clipper.file("vow", vow)`
- [ ] `clipper.file("calc", calc)`
- [ ] `vat.rely(clipper)`
- [ ] `dog.rely(clipper)`
- [ ] `clipper.rely(dog)`
- [ ] `clipper.rely(end)`
- [ ] `clipper.rely(clipperMom)`
- [ ] `clipper.rely(esm)`
- [ ] `flipper.deny(cat)` (replaced by the clipper)
- [ ] `flipper.deny(flipperMom)` (to avoid reenabling the flipper without governance delay)
- [ ] `osm.kiss(clipper)`
- [ ] `osm.kiss(clipperMom)`
- [ ] `dog.file(ilk, "hole", "")`
- [ ] `dog.file(ilk, "chop", "")`
- [ ] `clipper.file("buf", "")`
- [ ] `clipper.file("tail", "")`
- [ ] `clipper.file("cusp", "")`
- [ ] `clipper.file("chip", "")`
- [ ] `clipper.file("tip", "")`
- [ ] Ensure that the deployer was removed from the `calc`
- [ ] Ensure that the pause proxy was relied on the `calc`
- [ ] `calc.file("step", "")`
- [ ] `calc.file("cut", "")`
- [ ] `clipperMom.setPriceTolerance(clipper, ???)`
- [ ] `clipper.upchost()`
- [ ] Replace flipper to clipper in the `ilk-registry`
- [ ] Add `clipper` and `calc` in the `chainlog`
- [ ] Remove `flipper` from the `chainlog`

# Checklist

- [ ] Every contract variable/method declared as public/external private/internal
- [ ] Verify expiration (`4 days + 2 hours` monthly and `30 days` for the rest)
- [ ] Verify hash in the description matches [here](https://emn178.github.io/online-tools/keccak_256.html)
- [ ] Validate all addresses used are in Kovan changelog
- [ ] Deploy spell to kovan `SOLC_FLAGS="--optimize --optimize-runs=1" dapp --use solc:0.6.11 build --extract && dapp create DssSpell --gas=5000000 --gas-price="$(seth --to-wei 3 "gwei")"`
- [ ] Ensure contract is verified on `kovan` etherscan
- [ ] Change test to use kovan spell address and deploy timestamp
- [ ] Keep `Kovan-DssSpell.sol` and `Kovan-DssSpell.t.sol` the same, but make a copy in `archive`
- [ ] `squash and merge` this PR
